### PR TITLE
Add paginatable methods to all starr apps.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ lint:
 # If these catch legitimate uses, just remove the piece that caught it.
 nopollution:
 	# Avoid cross pollution.
-	grep -riE 'readar|radar|sonar|prowl|series|episode|author|book|edition|movie' lidarr   || exit 0 && exit 1
-	grep -riE 'readar|sonar|lidar|prowl|series|episode|author|book|artist|album' radarr   || exit 0 && exit 1
-	grep -riE 'radar|sonar|lidar|prowl|episode|movie|artist|album'  readarr  || exit 0 && exit 1
-	grep -riE 'readar|radar|lidar|prowl|book|edition|movie|artist|album' sonarr   || exit 0 && exit 1
-	grep -riE 'readar|radar|lidar|sonar|series|episode|author|book|edition|movie|artist|album|track' prowlarr || exit 0 && exit 1
+	grep -riE 'readar|radar|sonar|prowl|series|episode|author|book|edition|movie|v3' lidarr   || exit 0 && exit 1
+	grep -riE 'readar|sonar|lidar|prowl|series|episode|author|book|artist|album|v1' radarr   || exit 0 && exit 1
+	grep -riE 'radar|sonar|lidar|prowl|episode|movie|artist|album|v3'  readarr  || exit 0 && exit 1
+	grep -riE 'readar|radar|lidar|prowl|book|edition|movie|artist|album|v1' sonarr   || exit 0 && exit 1
+	grep -riE 'readar|radar|lidar|sonar|series|episode|author|book|edition|movie|artist|album|track|v3' prowlarr || exit 0 && exit 1
 
 generate:
 	go generate ./...

--- a/lidarr/lidarr.go
+++ b/lidarr/lidarr.go
@@ -130,14 +130,10 @@ func (l *Lidarr) GetQueue(records, perPage int) (*Queue, error) { //nolint:dupl
 func (l *Lidarr) GetQueuePage(params *starr.Req) (*Queue, error) {
 	var queue Queue
 
-	paramVals := params.Params()
-	paramVals.Set("includeUnknownArtistItems", "true")
+	params.CheckSet("sortKey", "timeleft")
+	params.CheckSet("includeUnknownArtistItems", "true")
 
-	if paramVals.Get("sortKey") == "" {
-		paramVals.Set("sortKey", "timeleft")
-	}
-
-	err := l.GetInto("v1/queue", paramVals, &queue)
+	err := l.GetInto("v1/queue", params.Params(), &queue)
 	if err != nil {
 		return nil, fmt.Errorf("api.Get(queue): %w", err)
 	}

--- a/lidarr/lidarr.go
+++ b/lidarr/lidarr.go
@@ -100,7 +100,7 @@ func (l *Lidarr) GetQueue(records, perPage int) (*Queue, error) { //nolint:dupl
 	queue := &Queue{Records: []*QueueRecord{}}
 	perPage = starr.SetPerPage(records, perPage)
 
-	for page := 0; ; page++ {
+	for page := 1; ; page++ {
 		curr, err := l.GetQueuePage(&starr.Req{PageSize: perPage, Page: page})
 		if err != nil {
 			return nil, err
@@ -382,7 +382,7 @@ func (l *Lidarr) GetHistory(records, perPage int) (*History, error) { //nolint:d
 	hist := &History{Records: []*HistoryRecord{}}
 	perPage = starr.SetPerPage(records, perPage)
 
-	for page := 0; ; page++ {
+	for page := 1; ; page++ {
 		curr, err := l.GetHistoryPage(&starr.Req{PageSize: perPage, Page: page})
 		if err != nil {
 			return nil, err

--- a/radarr/radarr.go
+++ b/radarr/radarr.go
@@ -157,14 +157,10 @@ func (r *Radarr) GetQueue(records, perPage int) (*Queue, error) { //nolint:dupl
 func (r *Radarr) GetQueuePage(params *starr.Req) (*Queue, error) {
 	var queue Queue
 
-	paramVals := params.Params()
-	paramVals.Set("includeUnknownMovieItems", "true")
+	params.CheckSet("sortKey", "timeleft")
+	params.CheckSet("includeUnknownMovieItems", "true")
 
-	if paramVals.Get("sortKey") == "" {
-		paramVals.Set("sortKey", "timeleft")
-	}
-
-	err := r.GetInto("v3/queue", paramVals, &queue)
+	err := r.GetInto("v3/queue", params.Params(), &queue)
 	if err != nil {
 		return nil, fmt.Errorf("api.Get(queue): %w", err)
 	}

--- a/radarr/radarr.go
+++ b/radarr/radarr.go
@@ -94,7 +94,6 @@ func (r *Radarr) GetHistory(records, perPage int) (*History, error) { //nolint:d
 
 			break
 		}
-		fmt.Println(len(hist.Records), perPage)
 
 		perPage = starr.AdjustPerPage(records, curr.TotalRecords, len(hist.Records), perPage)
 	}

--- a/radarr/radarr.go
+++ b/radarr/radarr.go
@@ -66,24 +66,48 @@ func (r *Radarr) AddTag(label string) (int, error) {
 }
 
 // GetHistory returns the Radarr History (grabs/failures/completed).
-func (r *Radarr) GetHistory(maxRecords, page int) (*History, error) {
-	if maxRecords < 1 {
-		maxRecords = 10
+// WARNING: 12/30/2021 - this method changed. The second argument no longer
+// controls which page is returned, but instead adjusts the pagination size.
+// If you need control over the page, use radarr.GetHistoryPage().
+// This function simply returns the number of history records desired,
+// up to the number of records present in the application.
+// It grabs records in (paginated) batches of perPage, and concatenates
+// them into one list.  Passing zero for records will return all of them.
+func (r *Radarr) GetHistory(records, perPage int) (*History, error) { //nolint:dupl
+	hist := &History{Records: []*HistoryRecord{}}
+	perPage = starr.SetPerPage(records, perPage)
+
+	for page := 0; ; page++ {
+		curr, err := r.GetHistoryPage(&starr.Req{PageSize: perPage, Page: page})
+		if err != nil {
+			return nil, err
+		}
+
+		hist.Records = append(hist.Records, curr.Records...)
+
+		if len(hist.Records) >= curr.TotalRecords ||
+			(len(hist.Records) >= records && records != 0) ||
+			len(curr.Records) == 0 {
+			hist.PageSize = curr.TotalRecords
+			hist.TotalRecords = curr.TotalRecords
+			hist.SortDirection = curr.SortDirection
+			hist.SortKey = curr.SortKey
+
+			break
+		}
+
+		perPage = starr.AdjustPerPage(records, curr.TotalRecords, len(hist.Records), perPage)
 	}
 
-	if page < 1 {
-		page = 1
-	}
+	return hist, nil
+}
 
-	params := make(url.Values)
-	params.Set("sortKey", "date")
-	params.Set("sortDir", "asc")
-	params.Set("pageSize", strconv.Itoa(maxRecords))
-	params.Set("page", strconv.Itoa(page))
-
+// GetHistoryPage returns a single page from the Radarr History (grabs/failures/completed).
+// The page size and number is configurable with the input request parameters.
+func (r *Radarr) GetHistoryPage(params *starr.Req) (*History, error) {
 	var history History
 
-	err := r.GetInto("v3/history", params, &history)
+	err := r.GetInto("v3/history", params.Params(), &history)
 	if err != nil {
 		return nil, fmt.Errorf("api.Get(history): %w", err)
 	}
@@ -91,26 +115,56 @@ func (r *Radarr) GetHistory(maxRecords, page int) (*History, error) {
 	return &history, nil
 }
 
-// GetQueue returns the Radarr Queue (processing, but not yet imported).
-func (r *Radarr) GetQueue(maxRecords, page int) (*Queue, error) {
-	if maxRecords < 1 {
-		maxRecords = 10
+// GetQueue returns a single page from the Radarr Queue (processing, but not yet imported).
+// WARNING: 12/30/2021 - this method changed. The second argument no longer
+// controls which page is returned, but instead adjusts the pagination size.
+// If you need control over the page, use radarr.GetQueuePage().
+// This function simply returns the number of queue records desired,
+// up to the number of records present in the application.
+// It grabs records in (paginated) batches of perPage, and concatenates
+// them into one list.  Passing zero for records will return all of them.
+func (r *Radarr) GetQueue(records, perPage int) (*Queue, error) { //nolint:dupl
+	queue := &Queue{Records: []*QueueRecord{}}
+	perPage = starr.SetPerPage(records, perPage)
+
+	for page := 0; ; page++ {
+		curr, err := r.GetQueuePage(&starr.Req{PageSize: perPage, Page: page})
+		if err != nil {
+			return nil, err
+		}
+
+		queue.Records = append(queue.Records, curr.Records...)
+
+		if len(queue.Records) >= curr.TotalRecords ||
+			(len(queue.Records) >= records && records != 0) ||
+			len(curr.Records) == 0 {
+			queue.PageSize = curr.TotalRecords
+			queue.TotalRecords = curr.TotalRecords
+			queue.SortDirection = curr.SortDirection
+			queue.SortKey = curr.SortKey
+
+			break
+		}
+
+		perPage = starr.AdjustPerPage(records, curr.TotalRecords, len(queue.Records), perPage)
 	}
 
-	if page < 1 {
-		page = 1
-	}
+	return queue, nil
+}
 
-	params := make(url.Values)
-	params.Set("sortKey", "timeleft")
-	params.Set("sortDir", "asc")
-	params.Set("pageSize", strconv.Itoa(maxRecords))
-	params.Set("page", strconv.Itoa(page))
-	params.Set("includeUnknownMovieItems", "true")
-
+// GetQueuePage returns a single page from the Radarr Queue.
+// The page size and number is configurable with the input request parameters.
+func (r *Radarr) GetQueuePage(params *starr.Req) (*Queue, error) {
 	var queue Queue
 
-	err := r.GetInto("v3/queue", params, &queue)
+	paramVals := params.Params()
+	paramVals.Set("includeUnknownMovieItems", "true")
+
+	if paramVals.Get("sortKey") == "" {
+		paramVals.Set("sortKey", "timeleft")
+	}
+
+	err := r.GetInto("v3/queue", paramVals, &queue)
 	if err != nil {
 		return nil, fmt.Errorf("api.Get(queue): %w", err)
 	}

--- a/radarr/radarr.go
+++ b/radarr/radarr.go
@@ -77,14 +77,13 @@ func (r *Radarr) GetHistory(records, perPage int) (*History, error) { //nolint:d
 	hist := &History{Records: []*HistoryRecord{}}
 	perPage = starr.SetPerPage(records, perPage)
 
-	for page := 0; ; page++ {
+	for page := 1; ; page++ {
 		curr, err := r.GetHistoryPage(&starr.Req{PageSize: perPage, Page: page})
 		if err != nil {
 			return nil, err
 		}
 
 		hist.Records = append(hist.Records, curr.Records...)
-
 		if len(hist.Records) >= curr.TotalRecords ||
 			(len(hist.Records) >= records && records != 0) ||
 			len(curr.Records) == 0 {
@@ -95,6 +94,7 @@ func (r *Radarr) GetHistory(records, perPage int) (*History, error) { //nolint:d
 
 			break
 		}
+		fmt.Println(len(hist.Records), perPage)
 
 		perPage = starr.AdjustPerPage(records, curr.TotalRecords, len(hist.Records), perPage)
 	}
@@ -127,14 +127,13 @@ func (r *Radarr) GetQueue(records, perPage int) (*Queue, error) { //nolint:dupl
 	queue := &Queue{Records: []*QueueRecord{}}
 	perPage = starr.SetPerPage(records, perPage)
 
-	for page := 0; ; page++ {
+	for page := 1; ; page++ {
 		curr, err := r.GetQueuePage(&starr.Req{PageSize: perPage, Page: page})
 		if err != nil {
 			return nil, err
 		}
 
 		queue.Records = append(queue.Records, curr.Records...)
-
 		if len(queue.Records) >= curr.TotalRecords ||
 			(len(queue.Records) >= records && records != 0) ||
 			len(curr.Records) == 0 {

--- a/radarr/type.go
+++ b/radarr/type.go
@@ -35,7 +35,7 @@ func New(config *starr.Config) *Radarr {
 	return &Radarr{APIer: config}
 }
 
-// SystemStatus is the /api/v1/system/status endpoint.
+// SystemStatus is the /api/v3/system/status endpoint.
 type SystemStatus struct {
 	Version           string    `json:"version"`
 	BuildTime         time.Time `json:"buildTime"`

--- a/readarr/readarr.go
+++ b/readarr/readarr.go
@@ -93,10 +93,10 @@ func (r *Readarr) GetQueue(records, perPage int) (*Queue, error) {
 func (r *Readarr) GetQueuePage(params *starr.Req) (*Queue, error) {
 	var queue Queue
 
-	paramVals := params.Params()
-	paramVals.Set("includeUnknownAuthorItems", "true")
+	params.CheckSet("sortKey", "timeleft")
+	params.CheckSet("includeUnknownAuthorItems", "true")
 
-	err := r.GetInto("v1/queue", paramVals, &queue)
+	err := r.GetInto("v1/queue", params.Params(), &queue)
 	if err != nil {
 		return nil, fmt.Errorf("api.Get(queue): %w", err)
 	}

--- a/readarr/readarr.go
+++ b/readarr/readarr.go
@@ -52,19 +52,51 @@ func (r *Readarr) AddTag(label string) (int, error) {
 	return tag.ID, nil
 }
 
-// GetQueue returns the Readarr Queue (processing, but not yet imported).
-func (r *Readarr) GetQueue(maxRecords int) (*Queue, error) {
-	if maxRecords < 1 {
-		maxRecords = 1
+// GetQueue returns a single page from the Readarr Queue (processing, but not yet imported).
+// WARNING: 12/30/2021 - this method changed.
+// If you need control over the page, use readarr.GetQueuePage().
+// This function simply returns the number of queue records desired,
+// up to the number of records present in the application.
+// It grabs records in (paginated) batches of perPage, and concatenates
+// them into one list.  Passing zero for records will return all of them.
+func (r *Readarr) GetQueue(records, perPage int) (*Queue, error) {
+	queue := &Queue{Records: []*QueueRecord{}}
+	perPage = starr.SetPerPage(records, perPage)
+
+	for page := 0; ; page++ {
+		curr, err := r.GetQueuePage(&starr.Req{PageSize: perPage, Page: page})
+		if err != nil {
+			return nil, err
+		}
+
+		queue.Records = append(queue.Records, curr.Records...)
+
+		if len(queue.Records) >= curr.TotalRecords ||
+			(len(queue.Records) >= records && records != 0) ||
+			len(curr.Records) == 0 {
+			queue.PageSize = curr.TotalRecords
+			queue.TotalRecords = curr.TotalRecords
+			queue.SortDirection = curr.SortDirection
+			queue.SortKey = curr.SortKey
+
+			break
+		}
+
+		perPage = starr.AdjustPerPage(records, curr.TotalRecords, len(queue.Records), perPage)
 	}
 
-	params := make(url.Values)
-	params.Set("pageSize", strconv.Itoa(maxRecords))
-	params.Set("includeUnknownAuthorItems", "true")
+	return queue, nil
+}
 
+// GetQueuePage returns a single page from the Readarr Queue.
+// The page size and number is configurable with the input request parameters.
+func (r *Readarr) GetQueuePage(params *starr.Req) (*Queue, error) {
 	var queue Queue
 
-	err := r.GetInto("v1/queue", params, &queue)
+	paramVals := params.Params()
+	paramVals.Set("includeUnknownAuthorItems", "true")
+
+	err := r.GetInto("v1/queue", paramVals, &queue)
 	if err != nil {
 		return nil, fmt.Errorf("api.Get(queue): %w", err)
 	}
@@ -286,18 +318,48 @@ func (r *Readarr) SendCommand(cmd *CommandRequest) (*CommandResponse, error) {
 	return &output, nil
 }
 
-// GetHistory returns the last few items from the history endpoint.
-func (r *Readarr) GetHistory(maxRecords int) (*History, error) {
-	if maxRecords < 1 {
-		maxRecords = 1
+// GetHistory returns the Readarr History (grabs/failures/completed).
+// WARNING: 12/30/2021 - this method changed.
+// If you need control over the page, use readarr.GetHistoryPage().
+// This function simply returns the number of history records desired,
+// up to the number of records present in the application.
+// It grabs records in (paginated) batches of perPage, and concatenates
+// them into one list.  Passing zero for records will return all of them.
+func (r *Readarr) GetHistory(records, perPage int) (*History, error) {
+	hist := &History{Records: []HistoryRecord{}}
+	perPage = starr.SetPerPage(records, perPage)
+
+	for page := 0; ; page++ {
+		curr, err := r.GetHistoryPage(&starr.Req{PageSize: perPage, Page: page})
+		if err != nil {
+			return nil, err
+		}
+
+		hist.Records = append(hist.Records, curr.Records...)
+
+		if len(hist.Records) >= curr.TotalRecords ||
+			(len(hist.Records) >= records && records != 0) ||
+			len(curr.Records) == 0 {
+			hist.PageSize = curr.TotalRecords
+			hist.TotalRecords = curr.TotalRecords
+			hist.SortDirection = curr.SortDirection
+			hist.SortKey = curr.SortKey
+
+			break
+		}
+
+		perPage = starr.AdjustPerPage(records, curr.TotalRecords, len(hist.Records), perPage)
 	}
 
-	params := make(url.Values)
-	params.Set("pageSize", strconv.Itoa(maxRecords))
+	return hist, nil
+}
 
+// GetHistoryPage returns a single page from the Readarr History (grabs/failures/completed).
+// The page size and number is configurable with the input request parameters.
+func (r *Readarr) GetHistoryPage(params *starr.Req) (*History, error) {
 	var history History
 
-	err := r.GetInto("v1/history", params, &history)
+	err := r.GetInto("v1/history", params.Params(), &history)
 	if err != nil {
 		return nil, fmt.Errorf("api.Get(history): %w", err)
 	}

--- a/readarr/readarr.go
+++ b/readarr/readarr.go
@@ -63,7 +63,7 @@ func (r *Readarr) GetQueue(records, perPage int) (*Queue, error) {
 	queue := &Queue{Records: []*QueueRecord{}}
 	perPage = starr.SetPerPage(records, perPage)
 
-	for page := 0; ; page++ {
+	for page := 1; ; page++ {
 		curr, err := r.GetQueuePage(&starr.Req{PageSize: perPage, Page: page})
 		if err != nil {
 			return nil, err
@@ -329,7 +329,7 @@ func (r *Readarr) GetHistory(records, perPage int) (*History, error) {
 	hist := &History{Records: []HistoryRecord{}}
 	perPage = starr.SetPerPage(records, perPage)
 
-	for page := 0; ; page++ {
+	for page := 1; ; page++ {
 		curr, err := r.GetHistoryPage(&starr.Req{PageSize: perPage, Page: page})
 		if err != nil {
 			return nil, err

--- a/shared.go
+++ b/shared.go
@@ -186,7 +186,7 @@ func (r *Req) Encode() string {
 }
 
 // CheckSet sets a request parameter if it's not already set.
-func (r *Req) CheckSet(key, value string) {
+func (r *Req) CheckSet(key, value string) { //nolint:cyclop
 	switch strings.ToLower(key) {
 	case "page":
 		if r.Page == 0 {
@@ -256,7 +256,7 @@ func SetPerPage(records, perPage int) int {
 // 'records' is the number requested, 'total' is the number in the app,
 // 'collected' is how many we have so far, and 'perPage' is the current perPage setting.
 func AdjustPerPage(records, total, collected, perPage int) int {
-	if d := records - collected; perPage > d {
+	if d := records - collected; perPage > d && d > 0 {
 		perPage = d
 	}
 

--- a/sonarr/sonarr.go
+++ b/sonarr/sonarr.go
@@ -10,26 +10,55 @@ import (
 	"golift.io/starr"
 )
 
-// GetQueue returns the Sonarr Queue (processing, but not yet imported).
-func (s *Sonarr) GetQueue(maxRecords, page int) (*Queue, error) {
-	if maxRecords < 1 {
-		maxRecords = 1
+// GetQueue returns a single page from the Sonarr Queue (processing, but not yet imported).
+// WARNING: 12/30/2021 - this method changed.
+// If you need control over the page, use sonarr.GetQueuePage().
+// This function simply returns the number of queue records desired,
+// up to the number of records present in the application.
+// It grabs records in (paginated) batches of perPage, and concatenates
+// them into one list.  Passing zero for records will return all of them.
+func (s *Sonarr) GetQueue(records, perPage int) (*Queue, error) { //nolint:dupl
+	queue := &Queue{Records: []*QueueRecord{}}
+	perPage = starr.SetPerPage(records, perPage)
+
+	for page := 0; ; page++ {
+		curr, err := s.GetQueuePage(&starr.Req{PageSize: perPage, Page: page})
+		if err != nil {
+			return nil, err
+		}
+
+		queue.Records = append(queue.Records, curr.Records...)
+
+		if len(queue.Records) >= curr.TotalRecords ||
+			(len(queue.Records) >= records && records != 0) ||
+			len(curr.Records) == 0 {
+			queue.PageSize = curr.TotalRecords
+			queue.TotalRecords = curr.TotalRecords
+			queue.SortDirection = curr.SortDirection
+			queue.SortKey = curr.SortKey
+
+			break
+		}
+
+		perPage = starr.AdjustPerPage(records, curr.TotalRecords, len(queue.Records), perPage)
 	}
 
-	if page < 1 {
-		page = 1
-	}
+	return queue, nil
+}
 
-	params := make(url.Values)
-	params.Set("sortKey", "timeleft")
-	params.Set("sortDir", "asc")
-	params.Set("pageSize", strconv.Itoa(maxRecords))
-	params.Set("page", strconv.Itoa(page))
-	params.Set("includeUnknownSeriesItems", "true")
-
+// GetQueuePage returns a single page from the Sonarr Queue.
+// The page size and number is configurable with the input request parameters.
+func (s *Sonarr) GetQueuePage(params *starr.Req) (*Queue, error) {
 	var queue Queue
 
-	err := s.GetInto("v3/queue", params, &queue)
+	paramVals := params.Params()
+	paramVals.Set("includeUnknownSeriesItems", "true")
+
+	if paramVals.Get("sortKey") == "" {
+		paramVals.Set("sortKey", "timeleft")
+	}
+
+	err := s.GetInto("v3/queue", paramVals, &queue)
 	if err != nil {
 		return nil, fmt.Errorf("api.Get(queue): %w", err)
 	}
@@ -380,18 +409,48 @@ func (s *Sonarr) MonitorEpisode(episodeIDs []int64, monitor bool) ([]*Episode, e
 	return output, nil
 }
 
-// GetHistory returns the last few items from the history endpoint.
-func (s *Sonarr) GetHistory(maxRecords int) (*History, error) {
-	if maxRecords < 1 {
-		maxRecords = 1
+// GetHistory returns the Sonarr History (grabs/failures/completed).
+// WARNING: 12/30/2021 - this method changed.
+// If you need control over the page, use sonarr.GetHistoryPage().
+// This function simply returns the number of history records desired,
+// up to the number of records present in the application.
+// It grabs records in (paginated) batches of perPage, and concatenates
+// them into one list.  Passing zero for records will return all of them.
+func (s *Sonarr) GetHistory(records, perPage int) (*History, error) { //nolint:dupl
+	hist := &History{Records: []*HistoryRecord{}}
+	perPage = starr.SetPerPage(records, perPage)
+
+	for page := 0; ; page++ {
+		curr, err := s.GetHistoryPage(&starr.Req{PageSize: perPage, Page: page})
+		if err != nil {
+			return nil, err
+		}
+
+		hist.Records = append(hist.Records, curr.Records...)
+
+		if len(hist.Records) >= curr.TotalRecords ||
+			(len(hist.Records) >= records && records != 0) ||
+			len(curr.Records) == 0 {
+			hist.PageSize = curr.TotalRecords
+			hist.TotalRecords = curr.TotalRecords
+			hist.SortDirection = curr.SortDirection
+			hist.SortKey = curr.SortKey
+
+			break
+		}
+
+		perPage = starr.AdjustPerPage(records, curr.TotalRecords, len(hist.Records), perPage)
 	}
 
-	params := make(url.Values)
-	params.Set("pageSize", strconv.Itoa(maxRecords))
+	return hist, nil
+}
 
+// GetHistoryPage returns a single page from the Sonarr History (grabs/failures/completed).
+// The page size and number is configurable with the input request parameters.
+func (s *Sonarr) GetHistoryPage(params *starr.Req) (*History, error) {
 	var history History
 
-	err := s.GetInto("v3/history", params, &history)
+	err := s.GetInto("v3/history", params.Params(), &history)
 	if err != nil {
 		return nil, fmt.Errorf("api.Get(history): %w", err)
 	}

--- a/sonarr/sonarr.go
+++ b/sonarr/sonarr.go
@@ -21,7 +21,7 @@ func (s *Sonarr) GetQueue(records, perPage int) (*Queue, error) { //nolint:dupl
 	queue := &Queue{Records: []*QueueRecord{}}
 	perPage = starr.SetPerPage(records, perPage)
 
-	for page := 0; ; page++ {
+	for page := 1; ; page++ {
 		curr, err := s.GetQueuePage(&starr.Req{PageSize: perPage, Page: page})
 		if err != nil {
 			return nil, err
@@ -416,7 +416,7 @@ func (s *Sonarr) GetHistory(records, perPage int) (*History, error) { //nolint:d
 	hist := &History{Records: []*HistoryRecord{}}
 	perPage = starr.SetPerPage(records, perPage)
 
-	for page := 0; ; page++ {
+	for page := 1; ; page++ {
 		curr, err := s.GetHistoryPage(&starr.Req{PageSize: perPage, Page: page})
 		if err != nil {
 			return nil, err

--- a/sonarr/sonarr.go
+++ b/sonarr/sonarr.go
@@ -51,14 +51,10 @@ func (s *Sonarr) GetQueue(records, perPage int) (*Queue, error) { //nolint:dupl
 func (s *Sonarr) GetQueuePage(params *starr.Req) (*Queue, error) {
 	var queue Queue
 
-	paramVals := params.Params()
-	paramVals.Set("includeUnknownSeriesItems", "true")
+	params.CheckSet("sortKey", "timeleft")
+	params.CheckSet("includeUnknownSeriesItems", "true")
 
-	if paramVals.Get("sortKey") == "" {
-		paramVals.Set("sortKey", "timeleft")
-	}
-
-	err := s.GetInto("v3/queue", paramVals, &queue)
+	err := s.GetInto("v3/queue", params.Params(), &queue)
 	if err != nil {
 		return nil, fmt.Errorf("api.Get(queue): %w", err)
 	}


### PR DESCRIPTION
This updates the GetHistory and GetQueue methods on all starr apps.

They are now "all the same" and take identical inputs. This breaks backward compatibility, sorry. A few minor updates and you should be good to go.

If you use to do `GetHistory(100)` you can now do `GetHistory(100, 100)` to do the same thing. Similar for `GetQueue()`. The main difference is that you can now pass `0` to get all records. `GetHistory(0,1000)` will download all items in batches of 1000.
