### PR TITLE
Add Fail to Lidarr and Readarr apps, clean up errors.

### DIFF
--- a/http.go
+++ b/http.go
@@ -92,7 +92,7 @@ func (c *Config) getBody(req *http.Request) (int, []byte, http.Header, error) {
 
 	// #############################################
 	// DEBUG: useful for viewing payloads from apps.
-	// fmt.Println(string(body))
+	// fmt.Println(resp.StatusCode, string(body))
 	// #############################################
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {

--- a/lidarr/lidarr.go
+++ b/lidarr/lidarr.go
@@ -420,6 +420,22 @@ func (l *Lidarr) GetHistoryPage(params *starr.Req) (*History, error) {
 	return &history, nil
 }
 
+// Fail marks the given history item as failed by id.
+func (l *Lidarr) Fail(historyID int64) error {
+	if historyID < 1 {
+		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
+	}
+
+	params := make(url.Values)
+
+	_, err := l.Get("v1/history/failed/"+strconv.FormatInt(historyID, starr.Base10), params)
+	if err != nil {
+		return fmt.Errorf("api.Get(history/failed): %w", err)
+	}
+
+	return nil
+}
+
 // Lookup will search for albums matching the specified search term.
 func (l *Lidarr) Lookup(term string) ([]*Album, error) {
 	var output []*Album

--- a/lidarr/lidarr.go
+++ b/lidarr/lidarr.go
@@ -426,8 +426,9 @@ func (l *Lidarr) Fail(historyID int64) error {
 		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
 	}
 
-	// Strangely uses a POST without a payload.
-	_, err := l.Post("v1/history/failed/"+strconv.FormatInt(historyID, starr.Base10), nil, nil)
+	post := []byte("id=" + strconv.FormatInt(historyID, starr.Base10))
+
+	_, err := l.Post("v1/history/failed", nil, post)
 	if err != nil {
 		return fmt.Errorf("api.Post(history/failed): %w", err)
 	}

--- a/lidarr/lidarr.go
+++ b/lidarr/lidarr.go
@@ -426,11 +426,10 @@ func (l *Lidarr) Fail(historyID int64) error {
 		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
 	}
 
-	params := make(url.Values)
-
-	_, err := l.Get("v1/history/failed/"+strconv.FormatInt(historyID, starr.Base10), params)
+	// Strangely uses a POST without a payload.
+	_, err := l.Post("v1/history/failed/"+strconv.FormatInt(historyID, starr.Base10), nil, nil)
 	if err != nil {
-		return fmt.Errorf("api.Get(history/failed): %w", err)
+		return fmt.Errorf("api.Post(history/failed): %w", err)
 	}
 
 	return nil

--- a/radarr/radarr.go
+++ b/radarr/radarr.go
@@ -299,9 +299,6 @@ func (r *Radarr) GetExclusions() ([]*Exclusion, error) {
 	return exclusions, nil
 }
 
-// ErrRequestError is returned when bad input is provided.
-var ErrRequestError = fmt.Errorf("request error")
-
 // DeleteExclusions removes exclusions from Radarr.
 func (r *Radarr) DeleteExclusions(ids []int64) error {
 	var errs string
@@ -314,7 +311,7 @@ func (r *Radarr) DeleteExclusions(ids []int64) error {
 	}
 
 	if errs != "" {
-		return fmt.Errorf("%w: %s", ErrRequestError, errs)
+		return fmt.Errorf("%w: %s", starr.ErrRequestError, errs)
 	}
 
 	return nil
@@ -429,7 +426,7 @@ func (r *Radarr) DeleteImportList(ids []int64) error {
 	}
 
 	if errs != "" {
-		return fmt.Errorf("%w: %s", ErrRequestError, errs)
+		return fmt.Errorf("%w: %s", starr.ErrRequestError, errs)
 	}
 
 	return nil
@@ -514,17 +511,17 @@ func (r *Radarr) GetBackupFiles() ([]*starr.BackupFile, error) {
 	return output, nil
 }
 
-// MarkHistoryItemAsFailed marks the given history item as failed by id.
+// Fail marks the given history item as failed by id.
 func (r *Radarr) Fail(historyID int64) error {
 	if historyID < 1 {
-		return fmt.Errorf("invalid history ID: %d", historyID)
+		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
 	}
 
 	params := make(url.Values)
 
-	_, err := r.Post("v3/history/failed/"+strconv.FormatInt(historyID, starr.Base10), params, nil)
+	_, err := r.Get("v3/history/failed/"+strconv.FormatInt(historyID, starr.Base10), params)
 	if err != nil {
-		return fmt.Errorf("api.Get(history/failed/): %w", err)
+		return fmt.Errorf("api.Get(history/failed): %w", err)
 	}
 
 	return nil

--- a/radarr/radarr.go
+++ b/radarr/radarr.go
@@ -517,11 +517,10 @@ func (r *Radarr) Fail(historyID int64) error {
 		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
 	}
 
-	params := make(url.Values)
-
-	_, err := r.Get("v3/history/failed/"+strconv.FormatInt(historyID, starr.Base10), params)
+	// Strangely uses a POST without a payload.
+	_, err := r.Post("v3/history/failed/"+strconv.FormatInt(historyID, starr.Base10), nil, nil)
 	if err != nil {
-		return fmt.Errorf("api.Get(history/failed): %w", err)
+		return fmt.Errorf("api.Post(history/failed): %w", err)
 	}
 
 	return nil

--- a/readarr/readarr.go
+++ b/readarr/readarr.go
@@ -373,11 +373,10 @@ func (r *Readarr) Fail(historyID int64) error {
 		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
 	}
 
-	params := make(url.Values)
-
-	_, err := r.Get("v1/history/failed/"+strconv.FormatInt(historyID, starr.Base10), params)
+	// Strangely uses a POST without a payload.
+	_, err := r.Post("v1/history/failed/"+strconv.FormatInt(historyID, starr.Base10), nil, nil)
 	if err != nil {
-		return fmt.Errorf("api.Get(history/failed): %w", err)
+		return fmt.Errorf("api.Post(history/failed): %w", err)
 	}
 
 	return nil

--- a/readarr/readarr.go
+++ b/readarr/readarr.go
@@ -373,8 +373,9 @@ func (r *Readarr) Fail(historyID int64) error {
 		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
 	}
 
-	// Strangely uses a POST without a payload.
-	_, err := r.Post("v1/history/failed/"+strconv.FormatInt(historyID, starr.Base10), nil, nil)
+	post := []byte("id=" + strconv.FormatInt(historyID, starr.Base10))
+
+	_, err := r.Post("v1/history/failed", nil, post)
 	if err != nil {
 		return fmt.Errorf("api.Post(history/failed): %w", err)
 	}

--- a/readarr/readarr.go
+++ b/readarr/readarr.go
@@ -367,6 +367,22 @@ func (r *Readarr) GetHistoryPage(params *starr.Req) (*History, error) {
 	return &history, nil
 }
 
+// Fail marks the given history item as failed by id.
+func (r *Readarr) Fail(historyID int64) error {
+	if historyID < 1 {
+		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
+	}
+
+	params := make(url.Values)
+
+	_, err := r.Get("v1/history/failed/"+strconv.FormatInt(historyID, starr.Base10), params)
+	if err != nil {
+		return fmt.Errorf("api.Get(history/failed): %w", err)
+	}
+
+	return nil
+}
+
 // Lookup will search for books matching the specified search term.
 func (r *Readarr) Lookup(term string) ([]*Book, error) {
 	var output []*Book

--- a/shared.go
+++ b/shared.go
@@ -162,13 +162,13 @@ func (r *Req) Params() url.Values {
 	if r.SortKey != "" {
 		params.Set("sortKey", r.SortKey)
 	} else {
-		params.Set("sortKey", "date") // timeleft
+		params.Set("sortKey", "date") // timeleft, title, id
 	}
 
 	if r.SortDir != "" {
-		params.Set("sortDir", r.SortDir)
+		params.Set("sortDirection", r.SortDir)
 	} else {
-		params.Set("sortDir", "asc") // desc
+		params.Set("sortDirection", "ascending") // descending
 	}
 
 	for k, v := range r.Values {
@@ -200,7 +200,7 @@ func (r *Req) CheckSet(key, value string) { //nolint:cyclop
 		if r.SortKey == "" {
 			r.SortKey = value
 		}
-	case "sortdir":
+	case "sortdirection":
 		if r.SortDir == "" {
 			r.SortDir = value
 		}
@@ -220,7 +220,7 @@ func (r *Req) Set(key, value string) {
 		r.PageSize, _ = strconv.Atoi(value)
 	case "sortkey":
 		r.SortKey = value
-	case "sortdir":
+	case "sortdirection":
 		r.SortDir = value
 	default:
 		if r.Values == nil {

--- a/sonarr/sonarr.go
+++ b/sonarr/sonarr.go
@@ -454,18 +454,17 @@ func (s *Sonarr) GetHistoryPage(params *starr.Req) (*History, error) {
 	return &history, nil
 }
 
-
 // Fail marks the given history item as failed by id.
 func (s *Sonarr) Fail(historyID int64) error {
 	if historyID < 1 {
-		return fmt.Errorf("invalid history ID: %d", historyID)
+		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
 	}
 
 	params := make(url.Values)
 
-	_, err := s.Post("v3/history/failed/"+strconv.FormatInt(historyID, starr.Base10), params, nil)
+	_, err := s.Get("v3/history/failed/"+strconv.FormatInt(historyID, starr.Base10), params)
 	if err != nil {
-		return fmt.Errorf("api.Get(history/failed/): %w", err)
+		return fmt.Errorf("api.Get(history/failed): %w", err)
 	}
 
 	return nil

--- a/sonarr/sonarr.go
+++ b/sonarr/sonarr.go
@@ -460,11 +460,10 @@ func (s *Sonarr) Fail(historyID int64) error {
 		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
 	}
 
-	params := make(url.Values)
-
-	_, err := s.Get("v3/history/failed/"+strconv.FormatInt(historyID, starr.Base10), params)
+	// Strangely uses a POST without a payload.
+	_, err := s.Post("v3/history/failed/"+strconv.FormatInt(historyID, starr.Base10), nil, nil)
 	if err != nil {
-		return fmt.Errorf("api.Get(history/failed): %w", err)
+		return fmt.Errorf("api.Post(history/failed): %w", err)
 	}
 
 	return nil

--- a/starr.go
+++ b/starr.go
@@ -42,6 +42,8 @@ var (
 	ErrNilInterface = fmt.Errorf("cannot unmarshal data into a nil or empty interface")
 	// ErrInvalidAPIKey is returned if we know the API key didn't work.
 	ErrInvalidAPIKey = fmt.Errorf("API Key may be incorrect")
+	// ErrRequestError is returned when bad input is provided.
+	ErrRequestError = fmt.Errorf("request error")
 )
 
 // Config is the data needed to poll Radarr or Sonarr or Lidarr or Readarr.


### PR DESCRIPTION
Compliments #14. Adds missing Fail() methods to Readarr and Lidarr. Cleans up existing methods in Sonarr and Radarr.