### PR TITLE
Make non-debug mode use less ram when processing

### DIFF
--- a/http.go
+++ b/http.go
@@ -34,11 +34,6 @@ func (c *Config) Req(ctx context.Context, path, method string, params url.Values
 		return resp.StatusCode, nil, resp.Header, fmt.Errorf("ioutil.ReadAll: %w", err)
 	}
 
-	// #############################################
-	// DEBUG: useful for viewing payloads from apps.
-	// log.Println(resp.StatusCode, resp.Header.Get("location"), string(body))
-	// #############################################
-
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return resp.StatusCode, respBody, resp.Header, fmt.Errorf("failed: %v (status: %s): %w: %s",
 			resp.Request.RequestURI, resp.Status, ErrInvalidStatusCode, string(respBody))

--- a/interface.go
+++ b/interface.go
@@ -21,10 +21,10 @@ import (
 // It changes once in a while, so avoid making hard dependencies on it.
 type APIer interface {
 	Login(ctx context.Context) error
-	// Normal data, returns http body.
+	// Normal data, returns response body.
 	Get(ctx context.Context, path string, params url.Values) (respBody []byte, err error)
-	Post(ctx context.Context, path string, params url.Values, postBody []byte) (respBody []byte, err error)
-	Put(ctx context.Context, path string, params url.Values, putBody []byte) (respBody []byte, err error)
+	Post(ctx context.Context, path string, params url.Values, postBody io.Reader) (respBody []byte, err error)
+	Put(ctx context.Context, path string, params url.Values, putBody io.Reader) (respBody []byte, err error)
 	Delete(ctx context.Context, path string, params url.Values) (respBody []byte, err error)
 	// Normal data, unmarshals into provided interface.
 	GetInto(ctx context.Context, path string, params url.Values, output interface{}) error
@@ -43,11 +43,8 @@ type APIer interface {
 // Config must satify the APIer struct.
 var _ APIer = (*Config)(nil)
 
-func (c *Config) log(code int, data, body []byte, header http.Header, path, method string, err error) {
-	if c.Debugf == nil {
-		return
-	}
-
+// log the request. Do not call this if c.Debugf is nil.
+func (c *Config) log(code int, data, body string, header http.Header, path, method string, err error) {
 	headers := ""
 
 	for header, value := range header {
@@ -56,22 +53,20 @@ func (c *Config) log(code int, data, body []byte, header http.Header, path, meth
 		}
 	}
 
-	bodyStr := string(body)
-	if c.MaxBody > 0 && len(bodyStr) > c.MaxBody {
-		bodyStr = bodyStr[:c.MaxBody] + " <body truncated>"
+	if c.MaxBody > 0 && len(body) > c.MaxBody {
+		body = body[:c.MaxBody] + " <body truncated>"
 	}
 
-	dataStr := string(data)
-	if c.MaxBody > 0 && len(dataStr) > c.MaxBody {
-		dataStr = dataStr[:c.MaxBody] + " <data truncated>"
+	if c.MaxBody > 0 && len(data) > c.MaxBody {
+		data = data[:c.MaxBody] + " <data truncated>"
 	}
 
 	if len(body) > 0 {
 		c.Debugf("Sent (%s) %d bytes to %s: %s\n Response: %s\n%s%s (err: %v)",
-			method, len(body), path, bodyStr, http.StatusText(code), headers, dataStr, err)
+			method, len(body), path, body, http.StatusText(code), headers, data, err)
 	} else {
 		c.Debugf("Sent (%s) to %s, Response: %s\n%s%s (err: %v)",
-			method, path, http.StatusText(code), headers, dataStr, err)
+			method, path, http.StatusText(code), headers, data, err)
 	}
 }
 
@@ -86,10 +81,10 @@ func (c *Config) Login(ctx context.Context) error {
 		c.Client.Jar = jar
 	}
 
-	post := []byte("username=" + c.Username + "&password=" + c.Password)
+	post := "username=" + c.Username + "&password=" + c.Password
 
-	code, resp, header, err := c.body(ctx, "/login", http.MethodPost, nil, bytes.NewBuffer(post))
-	c.log(code, nil, post, header, c.URL+"/login", http.MethodPost, err)
+	code, resp, header, err := c.body(ctx, "/login", http.MethodPost, nil, bytes.NewBufferString(post))
+	c.log(code, "", post, header, c.URL+"/login", http.MethodPost, err)
 
 	if err != nil {
 		return fmt.Errorf("authenticating as user '%s' failed: %w", c.Username, err)
@@ -111,23 +106,40 @@ func (c *Config) Login(ctx context.Context) error {
 // Get makes a GET http request and returns the body.
 func (c *Config) Get(ctx context.Context, path string, params url.Values) ([]byte, error) {
 	code, data, header, err := c.Req(ctx, path, http.MethodGet, params, nil)
-	c.log(code, data, nil, header, c.SetPathParams(path, params), http.MethodGet, err)
+
+	if c.Debugf != nil { // log the request.
+		c.log(code, string(data), "", header, c.SetPathParams(path, params), http.MethodGet, err)
+	}
 
 	return data, err
 }
 
 // Post makes a POST http request and returns the body.
-func (c *Config) Post(ctx context.Context, path string, params url.Values, postBody []byte) ([]byte, error) {
-	code, data, header, err := c.Req(ctx, path, http.MethodPost, params, bytes.NewBuffer(postBody))
-	c.log(code, data, postBody, header, c.SetPathParams(path, params), http.MethodPost, err)
+func (c *Config) Post(ctx context.Context, path string, params url.Values, postBody io.Reader) ([]byte, error) {
+	if c.Debugf == nil { // no log, pass it through.
+		_, data, _, err := c.Req(ctx, path, http.MethodPost, params, postBody)
+		return data, err
+	}
+
+	var buf bytes.Buffer                // split the reader for request and log.
+	tee := io.TeeReader(postBody, &buf) // must read tee first.
+	code, data, header, err := c.Req(ctx, path, http.MethodPost, params, tee)
+	c.log(code, string(data), buf.String(), header, c.SetPathParams(path, params), http.MethodPost, err)
 
 	return data, err
 }
 
 // Put makes a PUT http request and returns the body.
-func (c *Config) Put(ctx context.Context, path string, params url.Values, putBody []byte) ([]byte, error) {
-	code, data, header, err := c.Req(ctx, path, http.MethodPut, params, bytes.NewBuffer(putBody))
-	c.log(code, data, putBody, header, c.SetPathParams(path, params), http.MethodPut, err)
+func (c *Config) Put(ctx context.Context, path string, params url.Values, putBody io.Reader) ([]byte, error) {
+	if c.Debugf == nil { // no log, pass it through.
+		_, data, _, err := c.Req(ctx, path, http.MethodPut, params, putBody)
+		return data, err
+	}
+
+	var buf bytes.Buffer               // split the reader for request and log.
+	tee := io.TeeReader(putBody, &buf) // must read tee first.
+	code, data, header, err := c.Req(ctx, path, http.MethodPut, params, tee)
+	c.log(code, string(data), buf.String(), header, c.SetPathParams(path, params), http.MethodPut, err)
 
 	return data, err
 }
@@ -135,7 +147,10 @@ func (c *Config) Put(ctx context.Context, path string, params url.Values, putBod
 // Delete makes a DELETE http request and returns the body.
 func (c *Config) Delete(ctx context.Context, path string, params url.Values) ([]byte, error) {
 	code, data, header, err := c.Req(ctx, path, http.MethodDelete, params, nil)
-	c.log(code, data, nil, header, c.SetPathParams(path, params), http.MethodDelete, err)
+
+	if c.Debugf != nil {
+		c.log(code, string(data), "", header, c.SetPathParams(path, params), http.MethodDelete, err)
+	}
 
 	return data, err
 }
@@ -164,12 +179,7 @@ func (c *Config) PostInto(ctx context.Context,
 		return unmarshalBody(output, data, err)
 	}
 
-	var holder bytes.Buffer
-	if _, err := holder.ReadFrom(postBody); err != nil {
-		return fmt.Errorf("bytes buffer: %w", err)
-	}
-
-	data, err := c.Post(ctx, path, params, holder.Bytes()) // log the request
+	data, err := c.Post(ctx, path, params, postBody) // log the request
 
 	return unmarshal(output, data, err)
 }
@@ -184,12 +194,7 @@ func (c *Config) PutInto(ctx context.Context,
 		return unmarshalBody(output, data, err)
 	}
 
-	var holder bytes.Buffer
-	if _, err := holder.ReadFrom(putBody); err != nil {
-		return fmt.Errorf("bytes buffer: %w", err)
-	}
-
-	data, err := c.Put(ctx, path, params, holder.Bytes()) // log the request
+	data, err := c.Put(ctx, path, params, putBody) // log the request
 
 	return unmarshal(output, data, err)
 }
@@ -215,7 +220,10 @@ func (c *Config) DeleteInto(ctx context.Context, path string, params url.Values,
 // If it's not 200, it's possible the request had an error or was not authenticated.
 func (c *Config) GetBody(ctx context.Context, path string, params url.Values) (io.ReadCloser, int, error) {
 	code, data, header, err := c.body(ctx, path, http.MethodGet, params, nil)
-	c.log(code, nil, nil, header, c.URL+path, http.MethodGet, err)
+
+	if c.Debugf != nil {
+		c.log(code, "", "", header, c.URL+path, http.MethodGet, err)
+	}
 
 	return data, code, err
 }
@@ -227,7 +235,10 @@ func (c *Config) GetBody(ctx context.Context, path string, params url.Values) (i
 func (c *Config) PostBody(ctx context.Context,
 	path string, params url.Values, postBody io.Reader) (io.ReadCloser, int, error) {
 	code, data, header, err := c.body(ctx, path, http.MethodPost, params, postBody)
-	c.log(code, nil, nil, header, c.URL+path, http.MethodPost, err)
+
+	if c.Debugf != nil {
+		c.log(code, "", "", header, c.URL+path, http.MethodPost, err)
+	}
 
 	return data, code, err
 }
@@ -238,7 +249,10 @@ func (c *Config) PostBody(ctx context.Context,
 func (c *Config) PutBody(ctx context.Context,
 	path string, params url.Values, putBody io.Reader) (io.ReadCloser, int, error) {
 	code, data, header, err := c.body(ctx, path, http.MethodPut, params, putBody)
-	c.log(code, nil, nil, header, c.URL+path, http.MethodPut, err)
+
+	if c.Debugf != nil {
+		c.log(code, "", "", header, c.URL+path, http.MethodPut, err)
+	}
 
 	return data, code, err
 }
@@ -249,7 +263,10 @@ func (c *Config) PutBody(ctx context.Context,
 // If it's not 200, it's possible the request had an error or was not authenticated.
 func (c *Config) DeleteBody(ctx context.Context, path string, params url.Values) (io.ReadCloser, int, error) {
 	code, data, header, err := c.body(ctx, path, http.MethodDelete, params, nil)
-	c.log(code, nil, nil, header, c.URL+path, http.MethodDelete, err)
+
+	if c.Debugf != nil {
+		c.log(code, "", "", header, c.URL+path, http.MethodDelete, err)
+	}
 
 	return data, code, err
 }
@@ -268,7 +285,7 @@ func unmarshal(v interface{}, data []byte, err error) error {
 	return nil
 }
 
-// unmarshalBody is an extra procedure to check an error and unmarshal the payload.
+// unmarshalBody is an extra procedure to check an error and unmarshal the resp.Body payload.
 // This version unmarshals the resp.Body directly.
 func unmarshalBody(output interface{}, data io.ReadCloser, err error) error {
 	defer data.Close()

--- a/interface.go
+++ b/interface.go
@@ -118,6 +118,7 @@ func (c *Config) Get(ctx context.Context, path string, params url.Values) ([]byt
 func (c *Config) Post(ctx context.Context, path string, params url.Values, postBody io.Reader) ([]byte, error) {
 	if c.Debugf == nil { // no log, pass it through.
 		_, data, _, err := c.Req(ctx, path, http.MethodPost, params, postBody)
+
 		return data, err
 	}
 
@@ -133,6 +134,7 @@ func (c *Config) Post(ctx context.Context, path string, params url.Values, postB
 func (c *Config) Put(ctx context.Context, path string, params url.Values, putBody io.Reader) ([]byte, error) {
 	if c.Debugf == nil { // no log, pass it through.
 		_, data, _, err := c.Req(ctx, path, http.MethodPut, params, putBody)
+
 		return data, err
 	}
 

--- a/lidarr/artist.go
+++ b/lidarr/artist.go
@@ -1,6 +1,7 @@
 package lidarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -57,9 +58,9 @@ func (l *Lidarr) AddArtist(artist *Artist) (*Artist, error) {
 
 // AddArtistContext adds a new artist to Lidarr, and probably does not yet work.
 func (l *Lidarr) AddArtistContext(ctx context.Context, artist *Artist) (*Artist, error) {
-	body, err := json.Marshal(artist)
-	if err != nil {
-		return nil, fmt.Errorf("json.Marshal(album): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(artist); err != nil {
+		return nil, fmt.Errorf("json.Marshal(artist): %w", err)
 	}
 
 	params := make(url.Values)
@@ -67,7 +68,7 @@ func (l *Lidarr) AddArtistContext(ctx context.Context, artist *Artist) (*Artist,
 
 	var output Artist
 
-	err = l.PostInto(ctx, "v1/artist", params, body, &output)
+	err := l.PostInto(ctx, "v1/artist", params, &body, &output)
 	if err != nil {
 		return nil, fmt.Errorf("api.Post(artist): %w", err)
 	}
@@ -82,9 +83,9 @@ func (l *Lidarr) UpdateArtist(artist *Artist) (*Artist, error) {
 
 // UpdateArtistContext updates an artist in place.
 func (l *Lidarr) UpdateArtistContext(ctx context.Context, artist *Artist) (*Artist, error) {
-	body, err := json.Marshal(artist)
-	if err != nil {
-		return nil, fmt.Errorf("json.Marshal(album): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(artist); err != nil {
+		return nil, fmt.Errorf("json.Marshal(artist): %w", err)
 	}
 
 	params := make(url.Values)
@@ -92,7 +93,7 @@ func (l *Lidarr) UpdateArtistContext(ctx context.Context, artist *Artist) (*Arti
 
 	var output Artist
 
-	err = l.PutInto(ctx, "v1/artist/"+strconv.FormatInt(artist.ID, starr.Base10), params, body, &output)
+	err := l.PutInto(ctx, "v1/artist/"+strconv.FormatInt(artist.ID, starr.Base10), params, &body, &output)
 	if err != nil {
 		return nil, fmt.Errorf("api.Put(artist): %w", err)
 	}

--- a/lidarr/command.go
+++ b/lidarr/command.go
@@ -1,6 +1,7 @@
 package lidarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -35,12 +36,12 @@ func (l *Lidarr) SendCommandContext(ctx context.Context, cmd *CommandRequest) (*
 		return &output, nil
 	}
 
-	body, err := json.Marshal(cmd)
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(cmd); err != nil {
 		return nil, fmt.Errorf("json.Marshal(cmd): %w", err)
 	}
 
-	if err := l.PostInto(ctx, "v1/command", nil, body, &output); err != nil {
+	if err := l.PostInto(ctx, "v1/command", nil, &body, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(command): %w", err)
 	}
 

--- a/lidarr/history.go
+++ b/lidarr/history.go
@@ -1,6 +1,7 @@
 package lidarr
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strconv"
@@ -79,7 +80,7 @@ func (l *Lidarr) FailContext(ctx context.Context, historyID int64) error {
 		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
 	}
 
-	post := []byte("id=" + strconv.FormatInt(historyID, starr.Base10))
+	post := bytes.NewBufferString("id=" + strconv.FormatInt(historyID, starr.Base10))
 
 	_, err := l.Post(ctx, "v1/history/failed", nil, post)
 	if err != nil {

--- a/lidarr/qualityprofile.go
+++ b/lidarr/qualityprofile.go
@@ -1,6 +1,7 @@
 package lidarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -33,15 +34,13 @@ func (l *Lidarr) AddQualityProfile(profile *QualityProfile) (int64, error) {
 
 // AddQualityProfileContext updates a quality profile in place.
 func (l *Lidarr) AddQualityProfileContext(ctx context.Context, profile *QualityProfile) (int64, error) {
-	post, err := json.Marshal(profile)
-	if err != nil {
-		return 0, fmt.Errorf("json.Marshal(profile): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
+		return 0, fmt.Errorf("json.Marshal(qualityProfile): %w", err)
 	}
 
 	var output QualityProfile
-
-	err = l.PostInto(ctx, "v1/qualityProfile", nil, post, &output)
-	if err != nil {
+	if err := l.PostInto(ctx, "v1/qualityProfile", nil, &body, &output); err != nil {
 		return 0, fmt.Errorf("api.Post(qualityProfile): %w", err)
 	}
 

--- a/lidarr/qualityprofile.go
+++ b/lidarr/qualityprofile.go
@@ -54,12 +54,12 @@ func (l *Lidarr) UpdateQualityProfile(profile *QualityProfile) error {
 
 // UpdateQualityProfileContext updates a quality profile in place.
 func (l *Lidarr) UpdateQualityProfileContext(ctx context.Context, profile *QualityProfile) error {
-	put, err := json.Marshal(profile)
-	if err != nil {
-		return fmt.Errorf("json.Marshal(profile): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
+		return fmt.Errorf("json.Marshal(qualityProfile): %w", err)
 	}
 
-	_, err = l.Put(ctx, "v1/qualityProfile/"+strconv.FormatInt(profile.ID, starr.Base10), nil, put)
+	_, err := l.Put(ctx, "v1/qualityProfile/"+strconv.FormatInt(profile.ID, starr.Base10), nil, &body)
 	if err != nil {
 		return fmt.Errorf("api.Put(qualityProfile): %w", err)
 	}

--- a/lidarr/tag.go
+++ b/lidarr/tag.go
@@ -1,6 +1,7 @@
 package lidarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -33,13 +34,13 @@ func (l *Lidarr) AddTag(label string) (int, error) {
 
 // AddTagContext adds a tag or returns the ID for an existing tag.
 func (l *Lidarr) AddTagContext(ctx context.Context, label string) (int, error) {
-	body, err := json.Marshal(&starr.Tag{Label: label, ID: 0})
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label}); err != nil {
 		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
 	}
 
 	var tag starr.Tag
-	if err = l.PostInto(ctx, "v1/tag", nil, body, &tag); err != nil {
+	if err := l.PostInto(ctx, "v1/tag", nil, &body, &tag); err != nil {
 		return tag.ID, fmt.Errorf("api.Post(tag): %w", err)
 	}
 
@@ -53,13 +54,13 @@ func (l *Lidarr) UpdateTag(tagID int, label string) (int, error) {
 
 // UpdateTagContext updates the label for a tag.
 func (l *Lidarr) UpdateTagContext(ctx context.Context, tagID int, label string) (int, error) {
-	body, err := json.Marshal(&starr.Tag{Label: label, ID: tagID})
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label, ID: tagID}); err != nil {
 		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
 	}
 
 	var tag starr.Tag
-	if err = l.PutInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, body, &tag); err != nil {
+	if err := l.PutInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, &body, &tag); err != nil {
 		return tag.ID, fmt.Errorf("api.Put(tag): %w", err)
 	}
 

--- a/mocks/apier.go
+++ b/mocks/apier.go
@@ -156,7 +156,7 @@ func (mr *MockAPIerMockRecorder) Post(arg0, arg1, arg2, arg3 interface{}) *gomoc
 }
 
 // PostBody mocks base method.
-func (m *MockAPIer) PostBody(arg0 context.Context, arg1 string, arg2 url.Values, arg3 []byte) (io.ReadCloser, int, error) {
+func (m *MockAPIer) PostBody(arg0 context.Context, arg1 string, arg2 url.Values, arg3 io.Reader) (io.ReadCloser, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PostBody", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(io.ReadCloser)
@@ -172,7 +172,7 @@ func (mr *MockAPIerMockRecorder) PostBody(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // PostInto mocks base method.
-func (m *MockAPIer) PostInto(arg0 context.Context, arg1 string, arg2 url.Values, arg3 []byte, arg4 interface{}) error {
+func (m *MockAPIer) PostInto(arg0 context.Context, arg1 string, arg2 url.Values, arg3 io.Reader, arg4 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PostInto", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -201,7 +201,7 @@ func (mr *MockAPIerMockRecorder) Put(arg0, arg1, arg2, arg3 interface{}) *gomock
 }
 
 // PutBody mocks base method.
-func (m *MockAPIer) PutBody(arg0 context.Context, arg1 string, arg2 url.Values, arg3 []byte) (io.ReadCloser, int, error) {
+func (m *MockAPIer) PutBody(arg0 context.Context, arg1 string, arg2 url.Values, arg3 io.Reader) (io.ReadCloser, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutBody", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(io.ReadCloser)
@@ -217,7 +217,7 @@ func (mr *MockAPIerMockRecorder) PutBody(arg0, arg1, arg2, arg3 interface{}) *go
 }
 
 // PutInto mocks base method.
-func (m *MockAPIer) PutInto(arg0 context.Context, arg1 string, arg2 url.Values, arg3 []byte, arg4 interface{}) error {
+func (m *MockAPIer) PutInto(arg0 context.Context, arg1 string, arg2 url.Values, arg3 io.Reader, arg4 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutInto", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)

--- a/prowlarr/tag.go
+++ b/prowlarr/tag.go
@@ -1,6 +1,7 @@
 package prowlarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -33,13 +34,13 @@ func (p *Prowlarr) AddTag(label string) (int, error) {
 
 // AddTagContext adds a tag or returns the ID for an existing tag.
 func (p *Prowlarr) AddTagContext(ctx context.Context, label string) (int, error) {
-	body, err := json.Marshal(&starr.Tag{Label: label, ID: 0})
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label}); err != nil {
 		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
 	}
 
 	var tag starr.Tag
-	if err = p.PostInto(ctx, "v1/tag", nil, body, &tag); err != nil {
+	if err := p.PostInto(ctx, "v1/tag", nil, &body, &tag); err != nil {
 		return tag.ID, fmt.Errorf("api.Post(tag): %w", err)
 	}
 
@@ -53,13 +54,13 @@ func (p *Prowlarr) UpdateTag(tagID int, label string) (int, error) {
 
 // UpdateTagContext updates the label for a tag.
 func (p *Prowlarr) UpdateTagContext(ctx context.Context, tagID int, label string) (int, error) {
-	body, err := json.Marshal(&starr.Tag{Label: label, ID: tagID})
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label, ID: tagID}); err != nil {
 		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
 	}
 
 	var tag starr.Tag
-	if err = p.PutInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, body, &tag); err != nil {
+	if err := p.PutInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, &body, &tag); err != nil {
 		return tag.ID, fmt.Errorf("api.Put(tag): %w", err)
 	}
 

--- a/radarr/command.go
+++ b/radarr/command.go
@@ -1,6 +1,7 @@
 package radarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -35,12 +36,12 @@ func (r *Radarr) SendCommandContext(ctx context.Context, cmd *CommandRequest) (*
 		return &output, nil
 	}
 
-	body, err := json.Marshal(cmd)
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(cmd); err != nil {
 		return nil, fmt.Errorf("json.Marshal(cmd): %w", err)
 	}
 
-	if err := r.PostInto(ctx, "v3/command", nil, body, &output); err != nil {
+	if err := r.PostInto(ctx, "v3/command", nil, &body, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(command): %w", err)
 	}
 

--- a/radarr/customformat.go
+++ b/radarr/customformat.go
@@ -1,6 +1,7 @@
 package radarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -37,12 +38,12 @@ func (r *Radarr) AddCustomFormatContext(ctx context.Context, format *CustomForma
 
 	format.ID = 0 // ID must be zero when adding.
 
-	body, err := json.Marshal(format)
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(format); err != nil {
 		return nil, fmt.Errorf("json.Marshal(customFormat): %w", err)
 	}
 
-	if err := r.PostInto(ctx, "v3/customFormat", nil, body, &output); err != nil {
+	if err := r.PostInto(ctx, "v3/customFormat", nil, &body, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(customFormat): %w", err)
 	}
 
@@ -55,18 +56,18 @@ func (r *Radarr) UpdateCustomFormat(cf *CustomFormat, cfID int) (*CustomFormat, 
 }
 
 // UpdateCustomFormatContext updates an existing custom format and returns the response.
-func (r *Radarr) UpdateCustomFormatContext(ctx context.Context, cf *CustomFormat, cfID int) (*CustomFormat, error) {
+func (r *Radarr) UpdateCustomFormatContext(ctx context.Context, format *CustomFormat, cfID int) (*CustomFormat, error) {
 	if cfID == 0 {
-		cfID = cf.ID
+		cfID = format.ID
 	}
 
-	body, err := json.Marshal(cf)
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(format); err != nil {
 		return nil, fmt.Errorf("json.Marshal(customFormat): %w", err)
 	}
 
 	var output CustomFormat
-	if err := r.PutInto(ctx, "v3/customFormat/"+strconv.Itoa(cfID), nil, body, &output); err != nil {
+	if err := r.PutInto(ctx, "v3/customFormat/"+strconv.Itoa(cfID), nil, &body, &output); err != nil {
 		return nil, fmt.Errorf("api.Put(customFormat): %w", err)
 	}
 

--- a/radarr/exclusions.go
+++ b/radarr/exclusions.go
@@ -1,6 +1,7 @@
 package radarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -60,12 +61,12 @@ func (r *Radarr) AddExclusionsContext(ctx context.Context, exclusions []*Exclusi
 		exclusions[i].ID = 0
 	}
 
-	body, err := json.Marshal(exclusions)
-	if err != nil {
-		return fmt.Errorf("json.Marshal(movie): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(exclusions); err != nil {
+		return fmt.Errorf("json.Marshal(exclusions): %w", err)
 	}
 
-	_, err = r.Post(ctx, "v3/exclusions/bulk", nil, body)
+	_, err := r.Post(ctx, "v3/exclusions/bulk", nil, &body)
 	if err != nil {
 		return fmt.Errorf("api.Post(exclusions): %w", err)
 	}

--- a/radarr/importlist.go
+++ b/radarr/importlist.go
@@ -1,6 +1,7 @@
 package radarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -30,16 +31,16 @@ func (r *Radarr) CreateImportList(il *ImportList) (*ImportList, error) {
 }
 
 // CreateImportListContext creates an import list in Radarr.
-func (r *Radarr) CreateImportListContext(ctx context.Context, il *ImportList) (*ImportList, error) {
-	il.ID = 0
+func (r *Radarr) CreateImportListContext(ctx context.Context, list *ImportList) (*ImportList, error) {
+	list.ID = 0
 
-	body, err := json.Marshal(il)
-	if err != nil {
-		return nil, fmt.Errorf("json.Marshal(importlist): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(list); err != nil {
+		return nil, fmt.Errorf("json.Marshal(list): %w", err)
 	}
 
 	var output ImportList
-	if err := r.PostInto(ctx, "v3/importlist", nil, body, &output); err != nil {
+	if err := r.PostInto(ctx, "v3/importlist", nil, &body, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(importlist): %w", err)
 	}
 
@@ -76,14 +77,14 @@ func (r *Radarr) UpdateImportList(list *ImportList) (*ImportList, error) {
 
 // UpdateImportListContext updates an existing import list and returns the response.
 func (r *Radarr) UpdateImportListContext(ctx context.Context, list *ImportList) (*ImportList, error) {
-	body, err := json.Marshal(list)
-	if err != nil {
-		return nil, fmt.Errorf("json.Marshal(importlist): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(list); err != nil {
+		return nil, fmt.Errorf("json.Marshal(list): %w", err)
 	}
 
 	var output ImportList
 
-	err = r.PutInto(ctx, "v3/importlist/"+strconv.FormatInt(list.ID, starr.Base10), nil, body, &output)
+	err := r.PutInto(ctx, "v3/importlist/"+strconv.FormatInt(list.ID, starr.Base10), nil, &body, &output)
 	if err != nil {
 		return nil, fmt.Errorf("api.Put(importlist): %w", err)
 	}

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -57,15 +57,15 @@ func (r *Radarr) UpdateMovie(movieID int64, movie *Movie) error {
 
 // UpdateMovieContext sends a PUT request to update a movie in place.
 func (r *Radarr) UpdateMovieContext(ctx context.Context, movieID int64, movie *Movie) error {
-	put, err := json.Marshal(movie)
-	if err != nil {
-		return fmt.Errorf("json.Marshal(movie): %w", err)
-	}
-
 	params := make(url.Values)
 	params.Add("moveFiles", "true")
 
-	_, err = r.Put(ctx, "v3/movie/"+strconv.FormatInt(movieID, starr.Base10), params, put)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(movie); err != nil {
+		return fmt.Errorf("json.Marshal(movie): %w", err)
+	}
+
+	_, err := r.Put(ctx, "v3/movie/"+strconv.FormatInt(movieID, starr.Base10), params, &body)
 	if err != nil {
 		return fmt.Errorf("api.Put(movie): %w", err)
 	}

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -1,6 +1,7 @@
 package radarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -79,16 +80,16 @@ func (r *Radarr) AddMovie(movie *AddMovieInput) (*AddMovieOutput, error) {
 
 // AddMovieContext adds a movie to the queue.
 func (r *Radarr) AddMovieContext(ctx context.Context, movie *AddMovieInput) (*AddMovieOutput, error) {
-	body, err := json.Marshal(movie)
-	if err != nil {
-		return nil, fmt.Errorf("json.Marshal(movie): %w", err)
-	}
-
 	params := make(url.Values)
 	params.Add("moveFiles", "true")
 
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(movie); err != nil {
+		return nil, fmt.Errorf("json.Marshal(movie): %w", err)
+	}
+
 	var output AddMovieOutput
-	if err := r.PostInto(ctx, "v3/movie", params, body, &output); err != nil {
+	if err := r.PostInto(ctx, "v3/movie", params, &body, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(movie): %w", err)
 	}
 

--- a/radarr/qualityprofile.go
+++ b/radarr/qualityprofile.go
@@ -54,12 +54,12 @@ func (r *Radarr) UpdateQualityProfile(profile *QualityProfile) error {
 
 // UpdateQualityProfileContext updates a quality profile in place.
 func (r *Radarr) UpdateQualityProfileContext(ctx context.Context, profile *QualityProfile) error {
-	put, err := json.Marshal(profile)
-	if err != nil {
-		return fmt.Errorf("json.Marshal(profile): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
+		return fmt.Errorf("json.Marshal(qualityProfile): %w", err)
 	}
 
-	_, err = r.Put(ctx, "v3/qualityProfile/"+strconv.FormatInt(profile.ID, starr.Base10), nil, put)
+	_, err := r.Put(ctx, "v3/qualityProfile/"+strconv.FormatInt(profile.ID, starr.Base10), nil, &body)
 	if err != nil {
 		return fmt.Errorf("api.Put(qualityProfile): %w", err)
 	}

--- a/radarr/qualityprofile.go
+++ b/radarr/qualityprofile.go
@@ -1,6 +1,7 @@
 package radarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -33,15 +34,13 @@ func (r *Radarr) AddQualityProfile(profile *QualityProfile) (int64, error) {
 
 // AddQualityProfileContext updates a quality profile in place.
 func (r *Radarr) AddQualityProfileContext(ctx context.Context, profile *QualityProfile) (int64, error) {
-	post, err := json.Marshal(profile)
-	if err != nil {
-		return 0, fmt.Errorf("json.Marshal(profile): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
+		return 0, fmt.Errorf("json.Marshal(qualityProfile): %w", err)
 	}
 
 	var output QualityProfile
-
-	err = r.PostInto(ctx, "v3/qualityProfile", nil, post, &output)
-	if err != nil {
+	if err := r.PostInto(ctx, "v3/qualityProfile", nil, &body, &output); err != nil {
 		return 0, fmt.Errorf("api.Post(qualityProfile): %w", err)
 	}
 

--- a/radarr/tag.go
+++ b/radarr/tag.go
@@ -1,6 +1,7 @@
 package radarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -33,13 +34,13 @@ func (r *Radarr) UpdateTag(tagID int, label string) (int, error) {
 
 // UpdateTagContext updates the label for a tag.
 func (r *Radarr) UpdateTagContext(ctx context.Context, tagID int, label string) (int, error) {
-	body, err := json.Marshal(&starr.Tag{Label: label, ID: tagID})
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label, ID: tagID}); err != nil {
 		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
 	}
 
 	var tag starr.Tag
-	if err = r.PutInto(ctx, "v3/tag/"+strconv.Itoa(tagID), nil, body, &tag); err != nil {
+	if err := r.PutInto(ctx, "v3/tag/"+strconv.Itoa(tagID), nil, &body, &tag); err != nil {
 		return tag.ID, fmt.Errorf("api.Put(tag): %w", err)
 	}
 
@@ -53,13 +54,13 @@ func (r *Radarr) AddTag(label string) (int, error) {
 
 // AddTagContext adds a tag or returns the ID for an existing tag.
 func (r *Radarr) AddTagContext(ctx context.Context, label string) (int, error) {
-	body, err := json.Marshal(&starr.Tag{Label: label, ID: 0})
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label}); err != nil {
 		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
 	}
 
 	var tag starr.Tag
-	if err = r.PostInto(ctx, "v3/tag", nil, body, &tag); err != nil {
+	if err := r.PostInto(ctx, "v3/tag", nil, &body, &tag); err != nil {
 		return tag.ID, fmt.Errorf("api.Post(tag): %w", err)
 	}
 

--- a/readarr/author.go
+++ b/readarr/author.go
@@ -1,6 +1,7 @@
 package readarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -35,15 +36,15 @@ func (r *Readarr) UpdateAuthor(authorID int64, author *Author) error {
 
 // UpdateAuthorContext updates an author in place.
 func (r *Readarr) UpdateAuthorContext(ctx context.Context, authorID int64, author *Author) error {
-	put, err := json.Marshal(author)
-	if err != nil {
-		return fmt.Errorf("json.Marshal(author): %w", err)
-	}
-
 	params := make(url.Values)
 	params.Add("moveFiles", "true")
 
-	b, err := r.Put(ctx, "v1/author/"+strconv.FormatInt(authorID, starr.Base10), params, put)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(author); err != nil {
+		return fmt.Errorf("json.Marshal(author): %w", err)
+	}
+
+	b, err := r.Put(ctx, "v1/author/"+strconv.FormatInt(authorID, starr.Base10), params, &body)
 	if err != nil {
 		return fmt.Errorf("api.Put(author): %w", err)
 	}

--- a/readarr/book.go
+++ b/readarr/book.go
@@ -1,6 +1,7 @@
 package readarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -79,18 +80,16 @@ func (r *Readarr) AddBook(book *AddBookInput) (*AddBookOutput, error) {
 }
 
 func (r *Readarr) AddBookContext(ctx context.Context, book *AddBookInput) (*AddBookOutput, error) {
-	body, err := json.Marshal(book)
-	if err != nil {
-		return nil, fmt.Errorf("json.Marshal(book): %w", err)
-	}
-
 	params := make(url.Values)
 	params.Add("moveFiles", "true")
 
-	var output AddBookOutput
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(book); err != nil {
+		return nil, fmt.Errorf("json.Marshal(book): %w", err)
+	}
 
-	err = r.PostInto(ctx, "v1/book", params, body, &output)
-	if err != nil {
+	var output AddBookOutput
+	if err := r.PostInto(ctx, "v1/book", params, &body, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(book): %w", err)
 	}
 

--- a/readarr/book.go
+++ b/readarr/book.go
@@ -56,15 +56,15 @@ func (r *Readarr) UpdateBook(bookID int64, book *Book) error {
 }
 
 func (r *Readarr) UpdateBookContext(ctx context.Context, bookID int64, book *Book) error {
-	put, err := json.Marshal(book)
-	if err != nil {
-		return fmt.Errorf("json.Marshal(book): %w", err)
-	}
-
 	params := make(url.Values)
 	params.Add("moveFiles", "true")
 
-	b, err := r.Put(ctx, "v1/book/"+strconv.FormatInt(bookID, starr.Base10), params, put)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(book); err != nil {
+		return fmt.Errorf("json.Marshal(book): %w", err)
+	}
+
+	b, err := r.Put(ctx, "v1/book/"+strconv.FormatInt(bookID, starr.Base10), params, &body)
 	if err != nil {
 		return fmt.Errorf("api.Put(book): %w", err)
 	}

--- a/readarr/command.go
+++ b/readarr/command.go
@@ -1,6 +1,7 @@
 package readarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -34,12 +35,12 @@ func (r *Readarr) SendCommandContext(ctx context.Context, cmd *CommandRequest) (
 		return &output, nil
 	}
 
-	body, err := json.Marshal(cmd)
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(cmd); err != nil {
 		return nil, fmt.Errorf("json.Marshal(cmd): %w", err)
 	}
 
-	if err := r.PostInto(ctx, "v1/command", nil, body, &output); err != nil {
+	if err := r.PostInto(ctx, "v1/command", nil, &body, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(command): %w", err)
 	}
 

--- a/readarr/history.go
+++ b/readarr/history.go
@@ -1,6 +1,7 @@
 package readarr
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strconv"
@@ -75,9 +76,8 @@ func (r *Readarr) FailContext(ctx context.Context, historyID int64) error {
 		return fmt.Errorf("%w: invalid history ID: %d", starr.ErrRequestError, historyID)
 	}
 
-	post := []byte("id=" + strconv.FormatInt(historyID, starr.Base10))
-
-	_, err := r.Post(ctx, "v1/history/failed", nil, post)
+	_, err := r.Post(ctx,
+		"v1/history/failed", nil, bytes.NewBufferString("id="+strconv.FormatInt(historyID, starr.Base10)))
 	if err != nil {
 		return fmt.Errorf("api.Post(history/failed): %w", err)
 	}

--- a/readarr/qualityprofile.go
+++ b/readarr/qualityprofile.go
@@ -1,6 +1,7 @@
 package readarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -31,15 +32,13 @@ func (r *Readarr) AddQualityProfile(profile *QualityProfile) (int64, error) {
 }
 
 func (r *Readarr) AddQualityProfileContext(ctx context.Context, profile *QualityProfile) (int64, error) {
-	post, err := json.Marshal(profile)
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
 		return 0, fmt.Errorf("json.Marshal(profile): %w", err)
 	}
 
 	var output QualityProfile
-
-	err = r.PostInto(ctx, "v1/qualityProfile", nil, post, &output)
-	if err != nil {
+	if err := r.PostInto(ctx, "v1/qualityProfile", nil, &body, &output); err != nil {
 		return 0, fmt.Errorf("api.Post(qualityProfile): %w", err)
 	}
 

--- a/readarr/qualityprofile.go
+++ b/readarr/qualityprofile.go
@@ -34,7 +34,7 @@ func (r *Readarr) AddQualityProfile(profile *QualityProfile) (int64, error) {
 func (r *Readarr) AddQualityProfileContext(ctx context.Context, profile *QualityProfile) (int64, error) {
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(profile); err != nil {
-		return 0, fmt.Errorf("json.Marshal(profile): %w", err)
+		return 0, fmt.Errorf("json.Marshal(qualityProfile): %w", err)
 	}
 
 	var output QualityProfile
@@ -51,12 +51,12 @@ func (r *Readarr) UpdateQualityProfile(profile *QualityProfile) error {
 }
 
 func (r *Readarr) UpdateQualityProfileContext(ctx context.Context, profile *QualityProfile) error {
-	put, err := json.Marshal(profile)
-	if err != nil {
-		return fmt.Errorf("json.Marshal(profile): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
+		return fmt.Errorf("json.Marshal(qualityProfile): %w", err)
 	}
 
-	_, err = r.Put(ctx, "v1/qualityProfile/"+strconv.FormatInt(profile.ID, starr.Base10), nil, put)
+	_, err := r.Put(ctx, "v1/qualityProfile/"+strconv.FormatInt(profile.ID, starr.Base10), nil, &body)
 	if err != nil {
 		return fmt.Errorf("api.Put(qualityProfile): %w", err)
 	}

--- a/readarr/tag.go
+++ b/readarr/tag.go
@@ -1,6 +1,7 @@
 package readarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -31,13 +32,13 @@ func (r *Readarr) UpdateTag(tagID int, label string) (int, error) {
 }
 
 func (r *Readarr) UpdateTagContext(ctx context.Context, tagID int, label string) (int, error) {
-	body, err := json.Marshal(&starr.Tag{Label: label, ID: tagID})
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label, ID: tagID}); err != nil {
 		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
 	}
 
 	var tag starr.Tag
-	if err = r.PutInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, body, &tag); err != nil {
+	if err := r.PutInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, &body, &tag); err != nil {
 		return tag.ID, fmt.Errorf("api.Put(tag): %w", err)
 	}
 
@@ -50,13 +51,13 @@ func (r *Readarr) AddTag(label string) (int, error) {
 }
 
 func (r *Readarr) AddTagContext(ctx context.Context, label string) (int, error) {
-	body, err := json.Marshal(&starr.Tag{Label: label, ID: 0})
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label}); err != nil {
 		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
 	}
 
 	var tag starr.Tag
-	if err = r.PostInto(ctx, "v1/tag", nil, body, &tag); err != nil {
+	if err := r.PostInto(ctx, "v1/tag", nil, &body, &tag); err != nil {
 		return tag.ID, fmt.Errorf("api.Post(tag): %w", err)
 	}
 

--- a/sonarr/command.go
+++ b/sonarr/command.go
@@ -1,6 +1,7 @@
 package sonarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -37,12 +38,12 @@ func (s *Sonarr) SendCommandContext(ctx context.Context, cmd *CommandRequest) (*
 		return &output, nil
 	}
 
-	body, err := json.Marshal(cmd)
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(cmd); err != nil {
 		return nil, fmt.Errorf("json.Marshal(cmd): %w", err)
 	}
 
-	if err := s.PostInto(ctx, "v3/command", nil, body, &output); err != nil {
+	if err := s.PostInto(ctx, "v3/command", nil, &body, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(command): %w", err)
 	}
 

--- a/sonarr/episodefile.go
+++ b/sonarr/episodefile.go
@@ -1,6 +1,7 @@
 package sonarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -65,17 +66,17 @@ func (s *Sonarr) UpdateEpisodeFileQuality(episodeFileID, qualityID int64) (*Epis
 // UpdateEpisodeFileQualityContext updates an episode file, and takes a context.
 func (s *Sonarr) UpdateEpisodeFileQualityContext(ctx context.Context,
 	episodeFileID, qualityID int64) (*EpisodeFile, error) {
-	put, err := json.Marshal(&EpisodeFile{
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&EpisodeFile{
 		ID:      episodeFileID,
 		Quality: &starr.Quality{Quality: &starr.BaseQuality{ID: qualityID}},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("json.Marshal(episodeFile): %w", err)
+	}); err != nil {
+		return nil, fmt.Errorf("json.Marshal(episodeFileID): %w", err)
 	}
 
 	var output EpisodeFile
 
-	err = s.PutInto(ctx, "v3/episodeFile/"+strconv.FormatInt(episodeFileID, starr.Base10), nil, put, &output)
+	err := s.PutInto(ctx, "v3/episodeFile/"+strconv.FormatInt(episodeFileID, starr.Base10), nil, &body, &output)
 	if err != nil {
 		return nil, fmt.Errorf("api.Put(episodeFile): %w", err)
 	}

--- a/sonarr/qualityprofile.go
+++ b/sonarr/qualityprofile.go
@@ -34,7 +34,7 @@ func (s *Sonarr) AddQualityProfile(profile *QualityProfile) (int64, error) {
 func (s *Sonarr) AddQualityProfileContext(ctx context.Context, profile *QualityProfile) (int64, error) {
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(profile); err != nil {
-		return 0, fmt.Errorf("json.Marshal(profile): %w", err)
+		return 0, fmt.Errorf("json.Marshal(qualityProfile): %w", err)
 	}
 
 	var output QualityProfile
@@ -51,12 +51,12 @@ func (s *Sonarr) UpdateQualityProfile(profile *QualityProfile) error {
 }
 
 func (s *Sonarr) UpdateQualityProfileContext(ctx context.Context, profile *QualityProfile) error {
-	put, err := json.Marshal(profile)
-	if err != nil {
-		return fmt.Errorf("json.Marshal(profile): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
+		return fmt.Errorf("json.Marshal(qualityProfile): %w", err)
 	}
 
-	_, err = s.Put(ctx, "v3/qualityProfile/"+strconv.FormatInt(profile.ID, starr.Base10), nil, put)
+	_, err := s.Put(ctx, "v3/qualityProfile/"+strconv.FormatInt(profile.ID, starr.Base10), nil, &body)
 	if err != nil {
 		return fmt.Errorf("api.Put(qualityProfile): %w", err)
 	}

--- a/sonarr/qualityprofile.go
+++ b/sonarr/qualityprofile.go
@@ -1,6 +1,7 @@
 package sonarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -31,15 +32,13 @@ func (s *Sonarr) AddQualityProfile(profile *QualityProfile) (int64, error) {
 }
 
 func (s *Sonarr) AddQualityProfileContext(ctx context.Context, profile *QualityProfile) (int64, error) {
-	post, err := json.Marshal(profile)
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
 		return 0, fmt.Errorf("json.Marshal(profile): %w", err)
 	}
 
 	var output QualityProfile
-
-	err = s.PostInto(ctx, "v3/qualityProfile", nil, post, &output)
-	if err != nil {
+	if err := s.PostInto(ctx, "v3/qualityProfile", nil, &body, &output); err != nil {
 		return 0, fmt.Errorf("api.Post(qualityProfile): %w", err)
 	}
 

--- a/sonarr/releaseprofile.go
+++ b/sonarr/releaseprofile.go
@@ -51,12 +51,12 @@ func (s *Sonarr) UpdateReleaseProfile(profile *ReleaseProfile) error {
 }
 
 func (s *Sonarr) UpdateReleaseProfileContext(ctx context.Context, profile *ReleaseProfile) error {
-	put, err := json.Marshal(profile)
-	if err != nil {
-		return fmt.Errorf("json.Marshal(profile): %w", err)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
+		return fmt.Errorf("json.Marshal(releaseProfile): %w", err)
 	}
 
-	_, err = s.Put(ctx, "v3/releaseProfile/"+strconv.FormatInt(profile.ID, starr.Base10), nil, put)
+	_, err := s.Put(ctx, "v3/releaseProfile/"+strconv.FormatInt(profile.ID, starr.Base10), nil, &body)
 	if err != nil {
 		return fmt.Errorf("api.Put(releaseProfile): %w", err)
 	}

--- a/sonarr/releaseprofile.go
+++ b/sonarr/releaseprofile.go
@@ -1,6 +1,7 @@
 package sonarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -31,15 +32,13 @@ func (s *Sonarr) AddReleaseProfile(profile *ReleaseProfile) (int64, error) {
 }
 
 func (s *Sonarr) AddReleaseProfileContext(ctx context.Context, profile *ReleaseProfile) (int64, error) {
-	post, err := json.Marshal(profile)
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
 		return 0, fmt.Errorf("json.Marshal(profile): %w", err)
 	}
 
 	var output ReleaseProfile
-
-	err = s.PostInto(ctx, "v3/releaseProfile", nil, post, &output)
-	if err != nil {
+	if err := s.PostInto(ctx, "v3/releaseProfile", nil, &body, &output); err != nil {
 		return 0, fmt.Errorf("api.Post(releaseProfile): %w", err)
 	}
 

--- a/sonarr/seasonpass.go
+++ b/sonarr/seasonpass.go
@@ -1,6 +1,7 @@
 package sonarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -33,12 +34,12 @@ func (s *Sonarr) UpdateSeasonPass(seasonPass *SeasonPass) error {
 
 // UpdateSeasonPassContext allows monitoring many series and episodes at once.
 func (s *Sonarr) UpdateSeasonPassContext(ctx context.Context, seasonPass *SeasonPass) error {
-	body, err := json.Marshal(seasonPass)
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(seasonPass); err != nil {
 		return fmt.Errorf("json.Marshal(seasonPass): %w", err)
 	}
 
-	if _, err = s.Post(ctx, "v3/seasonPass", nil, body); err != nil {
+	if _, err := s.Post(ctx, "v3/seasonPass", nil, &body); err != nil {
 		return fmt.Errorf("api.Post(seasonPass): %w", err)
 	}
 

--- a/sonarr/series.go
+++ b/sonarr/series.go
@@ -1,6 +1,7 @@
 package sonarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -73,16 +74,16 @@ func (s *Sonarr) AddSeries(series *AddSeriesInput) (*AddSeriesOutput, error) {
 }
 
 func (s *Sonarr) AddSeriesContext(ctx context.Context, series *AddSeriesInput) (*AddSeriesOutput, error) {
-	body, err := json.Marshal(series)
-	if err != nil {
-		return nil, fmt.Errorf("json.Marshal(series): %w", err)
-	}
-
 	params := make(url.Values)
 	params.Add("moveFiles", "true")
 
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(series); err != nil {
+		return nil, fmt.Errorf("json.Marshal(series): %w", err)
+	}
+
 	var output AddSeriesOutput
-	if err = s.PostInto(ctx, "v3/series", params, body, &output); err != nil {
+	if err := s.PostInto(ctx, "v3/series", params, &body, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(series): %w", err)
 	}
 

--- a/sonarr/series.go
+++ b/sonarr/series.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/url"
 	"strconv"
 
@@ -50,20 +49,18 @@ func (s *Sonarr) UpdateSeries(seriesID int64, series *Series) error {
 }
 
 func (s *Sonarr) UpdateSeriesContext(ctx context.Context, seriesID int64, series *Series) error {
-	put, err := json.Marshal(series)
-	if err != nil {
-		return fmt.Errorf("json.Marshal(series): %w", err)
-	}
-
 	params := make(url.Values)
 	params.Add("moveFiles", "true")
 
-	b, err := s.Put(ctx, "v3/series/"+strconv.FormatInt(seriesID, starr.Base10), params, put)
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(series); err != nil {
+		return fmt.Errorf("json.Marshal(series): %w", err)
+	}
+
+	_, err := s.Put(ctx, "v3/series/"+strconv.FormatInt(seriesID, starr.Base10), params, &body)
 	if err != nil {
 		return fmt.Errorf("api.Put(series): %w", err)
 	}
-
-	log.Println("SHOW THIS TO CAPTAIN plz:", string(b))
 
 	return nil
 }

--- a/sonarr/tag.go
+++ b/sonarr/tag.go
@@ -1,6 +1,7 @@
 package sonarr
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -31,13 +32,13 @@ func (s *Sonarr) UpdateTag(tagID int, label string) (int, error) {
 }
 
 func (s *Sonarr) UpdateTagContext(ctx context.Context, tagID int, label string) (int, error) {
-	body, err := json.Marshal(&starr.Tag{Label: label, ID: tagID})
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label, ID: tagID}); err != nil {
 		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
 	}
 
 	var tag starr.Tag
-	if err = s.PutInto(ctx, "v3/tag/"+strconv.Itoa(tagID), nil, body, &tag); err != nil {
+	if err := s.PutInto(ctx, "v3/tag/"+strconv.Itoa(tagID), nil, &body, &tag); err != nil {
 		return tag.ID, fmt.Errorf("api.Put(tag): %w", err)
 	}
 
@@ -50,13 +51,13 @@ func (s *Sonarr) AddTag(label string) (int, error) {
 }
 
 func (s *Sonarr) AddTagContext(ctx context.Context, label string) (int, error) {
-	body, err := json.Marshal(&starr.Tag{Label: label, ID: 0})
-	if err != nil {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label}); err != nil {
 		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
 	}
 
 	var tag starr.Tag
-	if err = s.PostInto(ctx, "v3/tag", nil, body, &tag); err != nil {
+	if err := s.PostInto(ctx, "v3/tag", nil, &body, &tag); err != nil {
 		return tag.ID, fmt.Errorf("api.Post(tag): %w", err)
 	}
 

--- a/starr.go
+++ b/starr.go
@@ -92,7 +92,7 @@ func New(apiKey, appURL string, timeout time.Duration) *Config {
 		ValidSSL: false,
 		Timeout:  Duration{Duration: timeout},
 		Client:   nil, // Let each sub package handle its own client.
-		Debugf:   func(string, ...interface{}) {},
+		Debugf:   nil,
 	}
 }
 


### PR DESCRIPTION
The app currently stores a lot of crap in memory while processing large JSON payloads. This change makes the response body stream directly into the JSON decoder, saving a few cycles and a bytes in ram. It also uses a bytes Buffer (earlier) when passing incoming data off to the http request. 