### PR TITLE
feat(sonarr): add delayprofile qualitydefinition

### DIFF
--- a/sonarr/delayprofile.go
+++ b/sonarr/delayprofile.go
@@ -1,0 +1,108 @@
+package sonarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// DelayProfile is the /api/v3/delayprofile endpoint.
+type DelayProfile struct {
+	EnableUsenet           bool   `json:"enableUsenet"`
+	EnableTorrent          bool   `json:"enableTorrent"`
+	BypassIfHighestQuality bool   `json:"bypassIfHighestQuality"`
+	UsenetDelay            int64  `json:"usenetDelay"`
+	TorrentDelay           int64  `json:"torrentDelay"`
+	ID                     int64  `json:"id,omitempty"`
+	Order                  int64  `json:"order"`
+	Tags                   []int  `json:"tags"`
+	PreferredProtocol      string `json:"preferredProtocol"`
+}
+
+// GetDelayProfiles returns all configured delay profiles.
+func (s *Sonarr) GetDelayProfiles() ([]*DelayProfile, error) {
+	return s.GetDelayProfilesContext(context.Background())
+}
+
+func (s *Sonarr) GetDelayProfilesContext(ctx context.Context) ([]*DelayProfile, error) {
+	var output []*DelayProfile
+
+	if _, err := s.GetInto(ctx, "v3/delayProfile", nil, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(delayProfile): %w", err)
+	}
+
+	return output, nil
+}
+
+// GetDelayProfile returns a single delay profile.
+func (s *Sonarr) GetDelayProfile(profileID int) (*DelayProfile, error) {
+	return s.GetDelayProfileContext(context.Background(), profileID)
+}
+
+func (s *Sonarr) GetDelayProfileContext(ctx context.Context, profileID int) (*DelayProfile, error) {
+	var output *DelayProfile
+
+	id := strconv.Itoa(profileID)
+	if _, err := s.GetInto(ctx, "v3/delayProfile/"+id, nil, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(delayProfile): %w", err)
+	}
+
+	return output, nil
+}
+
+// AddDelayProfile creates a delay profile.
+func (s *Sonarr) AddDelayProfile(profile *DelayProfile) (*DelayProfile, error) {
+	return s.AddDelayProfileContext(context.Background(), profile)
+}
+
+func (s *Sonarr) AddDelayProfileContext(ctx context.Context, profile *DelayProfile) (*DelayProfile, error) {
+	var output DelayProfile
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
+		return nil, fmt.Errorf("json.Marshal(delayProfile): %w", err)
+	}
+
+	if _, err := s.PostInto(ctx, "v3/delayProfile", nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(delayProfile): %w", err)
+	}
+
+	return &output, nil
+}
+
+// UpdateDelayProfile updates the delay profile.
+func (s *Sonarr) UpdateDelayProfile(profile *DelayProfile) (*DelayProfile, error) {
+	return s.UpdateDelayProfileContext(context.Background(), profile)
+}
+
+func (s *Sonarr) UpdateDelayProfileContext(ctx context.Context, profile *DelayProfile) (*DelayProfile, error) {
+	var output DelayProfile
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
+		return nil, fmt.Errorf("json.Marshal(delayProfile): %w", err)
+	}
+
+	id := strconv.Itoa(int(profile.ID))
+	if _, err := s.PutInto(ctx, "v3/delayProfile/"+id, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(delayProfile): %w", err)
+	}
+
+	return &output, nil
+}
+
+// DeleteDelayProfile removes a single delay profile.
+func (s *Sonarr) DeleteDelayProfile(profileID int) error {
+	return s.DeleteDelayProfileContext(context.Background(), profileID)
+}
+
+func (s *Sonarr) DeleteDelayProfileContext(ctx context.Context, profileID int) error {
+	id := strconv.Itoa(profileID)
+	if _, err := s.Delete(ctx, "v3/delayProfile/"+id, nil); err != nil {
+		return fmt.Errorf("api.Delete(delayProfile): %w", err)
+	}
+
+	return nil
+}

--- a/sonarr/qualitydefinition.go
+++ b/sonarr/qualitydefinition.go
@@ -1,0 +1,74 @@
+package sonarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"golift.io/starr"
+)
+
+// QualityDefinition is the /api/v3/qualitydefinition endpoint.
+type QualityDefinition struct {
+	ID        int64            `json:"id,omitempty"`
+	Weight    int64            `json:"weight"`
+	MinSize   float64          `json:"minSize"`
+	MaxSize   float64          `json:"maxSize"`
+	Title     string           `json:"title"`
+	Qualities []*starr.Quality `json:"items"`
+}
+
+// GetQualityDefinitions returns all configured quality definitions.
+func (s *Sonarr) GetQualityDefinitions() ([]*QualityDefinition, error) {
+	return s.GetQualityDefinitionsContext(context.Background())
+}
+
+func (s *Sonarr) GetQualityDefinitionsContext(ctx context.Context) ([]*QualityDefinition, error) {
+	var output []*QualityDefinition
+
+	if _, err := s.GetInto(ctx, "v3/qualityDefinition", nil, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(qualityDefinition): %w", err)
+	}
+
+	return output, nil
+}
+
+// GetQualityDefinition returns a single quality definition.
+func (s *Sonarr) GetQualityDefinition(qualityDefinitionID int) (*QualityDefinition, error) {
+	return s.GetQualityDefinitionContext(context.Background(), qualityDefinitionID)
+}
+
+func (s *Sonarr) GetQualityDefinitionContext(ctx context.Context, qualityDefinitionID int) (*QualityDefinition, error) {
+	var output *QualityDefinition
+
+	id := strconv.Itoa(qualityDefinitionID)
+	if _, err := s.GetInto(ctx, "v3/qualityDefinition/"+id, nil, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(qualityDefinition): %w", err)
+	}
+
+	return output, nil
+}
+
+// UpdateQualityDefinition updates the quality definition.
+func (s *Sonarr) UpdateQualityDefinition(definition *QualityDefinition) (*QualityDefinition, error) {
+	return s.UpdateQualityDefinitionContext(context.Background(), definition)
+}
+
+func (s *Sonarr) UpdateQualityDefinitionContext(ctx context.Context,
+	definition *QualityDefinition) (*QualityDefinition, error) {
+	var output QualityDefinition
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(definition); err != nil {
+		return nil, fmt.Errorf("json.Marshal(qualityDefinition): %w", err)
+	}
+
+	id := strconv.Itoa(int(definition.ID))
+	if _, err := s.PutInto(ctx, "v3/qualityDefinition/"+id, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(qualityDefinition): %w", err)
+	}
+
+	return &output, nil
+}


### PR DESCRIPTION
Hi @davidnewhall,
First part of #37, with the new features (delayprofile and qualitydefinition)
Once this is merged I'll rebase #37 with the changes in languageprofile, qualityprofile, and releaseprofile.

If that works well, then we can plan to change the other methods as well