### PR TITLE
feat!: tags ids to objects with tests

### DIFF
--- a/lidarr/tag.go
+++ b/lidarr/tag.go
@@ -5,66 +5,27 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"strconv"
 
 	"golift.io/starr"
 )
 
-// GetTags returns all the tags.
+const bpTag = APIver + "/tag"
+
+// GetTags returns all configured tags.
 func (l *Lidarr) GetTags() ([]*starr.Tag, error) {
 	return l.GetTagsContext(context.Background())
 }
 
-// GetTagsContext returns all the tags.
 func (l *Lidarr) GetTagsContext(ctx context.Context) ([]*starr.Tag, error) {
-	var tags []*starr.Tag
+	var output []*starr.Tag
 
-	_, err := l.GetInto(ctx, "v1/tag", nil, &tags)
-	if err != nil {
+	if _, err := l.GetInto(ctx, bpTag, nil, &output); err != nil {
 		return nil, fmt.Errorf("api.Get(tag): %w", err)
 	}
 
-	return tags, nil
-}
-
-// AddTag adds a tag or returns the ID for an existing tag.
-func (l *Lidarr) AddTag(label string) (int, error) {
-	return l.AddTagContext(context.Background(), label)
-}
-
-// AddTagContext adds a tag or returns the ID for an existing tag.
-func (l *Lidarr) AddTagContext(ctx context.Context, label string) (int, error) {
-	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label}); err != nil {
-		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
-	}
-
-	var tag starr.Tag
-	if _, err := l.PostInto(ctx, "v1/tag", nil, &body, &tag); err != nil {
-		return tag.ID, fmt.Errorf("api.Post(tag): %w", err)
-	}
-
-	return tag.ID, nil
-}
-
-// UpdateTag updates the label for a tag.
-func (l *Lidarr) UpdateTag(tagID int, label string) (int, error) {
-	return l.UpdateTagContext(context.Background(), tagID, label)
-}
-
-// UpdateTagContext updates the label for a tag.
-func (l *Lidarr) UpdateTagContext(ctx context.Context, tagID int, label string) (int, error) {
-	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label, ID: tagID}); err != nil {
-		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
-	}
-
-	var tag starr.Tag
-	if _, err := l.PutInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, &body, &tag); err != nil {
-		return tag.ID, fmt.Errorf("api.Put(tag): %w", err)
-	}
-
-	return tag.ID, nil
+	return output, nil
 }
 
 // GetTag returns a single tag.
@@ -73,14 +34,55 @@ func (l *Lidarr) GetTag(tagID int) (*starr.Tag, error) {
 }
 
 func (l *Lidarr) GetTagContext(ctx context.Context, tagID int) (*starr.Tag, error) {
-	var tag *starr.Tag
+	var output *starr.Tag
 
-	_, err := l.GetInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, &tag)
-	if err != nil {
+	uri := path.Join(bpTag, strconv.Itoa(tagID))
+	if _, err := l.GetInto(ctx, uri, nil, &output); err != nil {
 		return nil, fmt.Errorf("api.Get(tag): %w", err)
 	}
 
-	return tag, nil
+	return output, nil
+}
+
+// AddTag creates a tag.
+func (l *Lidarr) AddTag(tag *starr.Tag) (*starr.Tag, error) {
+	return l.AddTagContext(context.Background(), tag)
+}
+
+func (l *Lidarr) AddTagContext(ctx context.Context, tag *starr.Tag) (*starr.Tag, error) {
+	var output starr.Tag
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(tag); err != nil {
+		return nil, fmt.Errorf("json.Marshal(tag): %w", err)
+	}
+
+	if _, err := l.PostInto(ctx, bpTag, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(tag): %w", err)
+	}
+
+	return &output, nil
+}
+
+// UpdateTag updates the tag.
+func (l *Lidarr) UpdateTag(tag *starr.Tag) (*starr.Tag, error) {
+	return l.UpdateTagContext(context.Background(), tag)
+}
+
+func (l *Lidarr) UpdateTagContext(ctx context.Context, tag *starr.Tag) (*starr.Tag, error) {
+	var output starr.Tag
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(tag); err != nil {
+		return nil, fmt.Errorf("json.Marshal(tag): %w", err)
+	}
+
+	uri := path.Join(bpTag, strconv.Itoa(tag.ID))
+	if _, err := l.PutInto(ctx, uri, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(tag): %w", err)
+	}
+
+	return &output, nil
 }
 
 // DeleteTag removes a single tag.
@@ -89,8 +91,8 @@ func (l *Lidarr) DeleteTag(tagID int) error {
 }
 
 func (l *Lidarr) DeleteTagContext(ctx context.Context, tagID int) error {
-	_, err := l.Delete(ctx, "v1/tag/"+strconv.Itoa(tagID), nil)
-	if err != nil {
+	uri := path.Join(bpTag, strconv.Itoa(tagID))
+	if _, err := l.Delete(ctx, uri, nil); err != nil {
 		return fmt.Errorf("api.Delete(tag): %w", err)
 	}
 

--- a/lidarr/tag_test.go
+++ b/lidarr/tag_test.go
@@ -1,0 +1,279 @@
+package lidarr_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/lidarr"
+)
+
+func TestGetTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		expectedResponse []*starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v1/tag",
+			responseStatus: 200,
+			responseBody:   "[{\"label\": \"flac\",\"id\": 1},{\"label\": \"mp3\",\"id\": 2}]",
+			expectedResponse: []*starr.Tag{
+				{
+					Label: "flac",
+					ID:    1,
+				},
+				{
+					Label: "mp3",
+					ID:    2,
+				},
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			expectedPath:     "/api/v1/tag",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetTags()
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		tagID            int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			tagID:          1,
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 200,
+			responseBody:   "{\"label\": \"flac\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "flac",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			tagID:            1,
+			expectedPath:     "/api/v1/tag/1",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetTag(test.tagID)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		tag              *starr.Tag
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v1/tag",
+			responseStatus: 200,
+			tag: &starr.Tag{
+				Label: "flac",
+			},
+			responseBody: "{\"label\": \"flac\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "flac",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			expectedPath:     "/api/v1/tag",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddTag(test.tag)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		tag              *starr.Tag
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 200,
+			tag: &starr.Tag{
+				Label: "flac",
+				ID:    1,
+			},
+			responseBody: "{\"label\": \"flac\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "flac",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:         "404",
+			expectedPath: "/api/v1/tag/1",
+			tag: &starr.Tag{
+				Label: "flac",
+				ID:    1,
+			},
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateTag(test.tag)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus int
+		tagID          int
+		name           string
+		expectedPath   string
+		responseBody   string
+		withError      error
+	}{
+		{
+			name:           "200",
+			tagID:          1,
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 200,
+			responseBody:   "{}",
+			withError:      nil,
+		},
+		{
+			name:           "404",
+			tagID:          1,
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 404,
+			responseBody:   `{"message": "NotFound"}`,
+			withError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteTag(test.tagID)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+		})
+	}
+}

--- a/prowlarr/prowlarr.go
+++ b/prowlarr/prowlarr.go
@@ -12,6 +12,9 @@ type Prowlarr struct {
 	starr.APIer
 }
 
+// APIver is the Prowlarr API version supported by this library.
+const APIver = "v1"
+
 // New returns a Prowlarr object used to interact with the Prowlarr API.
 func New(config *starr.Config) *Prowlarr {
 	if config.Client == nil {

--- a/prowlarr/tag.go
+++ b/prowlarr/tag.go
@@ -5,66 +5,27 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"strconv"
 
 	"golift.io/starr"
 )
 
-// GetTags returns all the tags.
+const bpTag = APIver + "/tag"
+
+// GetTags returns all configured tags.
 func (p *Prowlarr) GetTags() ([]*starr.Tag, error) {
 	return p.GetTagsContext(context.Background())
 }
 
-// GetTagsContext returns all the tags.
 func (p *Prowlarr) GetTagsContext(ctx context.Context) ([]*starr.Tag, error) {
-	var tags []*starr.Tag
+	var output []*starr.Tag
 
-	_, err := p.GetInto(ctx, "v1/tag", nil, &tags)
-	if err != nil {
+	if _, err := p.GetInto(ctx, bpTag, nil, &output); err != nil {
 		return nil, fmt.Errorf("api.Get(tag): %w", err)
 	}
 
-	return tags, nil
-}
-
-// AddTag adds a tag or returns the ID for an existing tag.
-func (p *Prowlarr) AddTag(label string) (int, error) {
-	return p.AddTagContext(context.Background(), label)
-}
-
-// AddTagContext adds a tag or returns the ID for an existing tag.
-func (p *Prowlarr) AddTagContext(ctx context.Context, label string) (int, error) {
-	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label}); err != nil {
-		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
-	}
-
-	var tag starr.Tag
-	if _, err := p.PostInto(ctx, "v1/tag", nil, &body, &tag); err != nil {
-		return tag.ID, fmt.Errorf("api.Post(tag): %w", err)
-	}
-
-	return tag.ID, nil
-}
-
-// UpdateTag updates the label for a tag.
-func (p *Prowlarr) UpdateTag(tagID int, label string) (int, error) {
-	return p.UpdateTagContext(context.Background(), tagID, label)
-}
-
-// UpdateTagContext updates the label for a tag.
-func (p *Prowlarr) UpdateTagContext(ctx context.Context, tagID int, label string) (int, error) {
-	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label, ID: tagID}); err != nil {
-		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
-	}
-
-	var tag starr.Tag
-	if _, err := p.PutInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, &body, &tag); err != nil {
-		return tag.ID, fmt.Errorf("api.Put(tag): %w", err)
-	}
-
-	return tag.ID, nil
+	return output, nil
 }
 
 // GetTag returns a single tag.
@@ -73,14 +34,55 @@ func (p *Prowlarr) GetTag(tagID int) (*starr.Tag, error) {
 }
 
 func (p *Prowlarr) GetTagContext(ctx context.Context, tagID int) (*starr.Tag, error) {
-	var tag *starr.Tag
+	var output *starr.Tag
 
-	_, err := p.GetInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, &tag)
-	if err != nil {
+	uri := path.Join(bpTag, strconv.Itoa(tagID))
+	if _, err := p.GetInto(ctx, uri, nil, &output); err != nil {
 		return nil, fmt.Errorf("api.Get(tag): %w", err)
 	}
 
-	return tag, nil
+	return output, nil
+}
+
+// AddTag creates a tag.
+func (p *Prowlarr) AddTag(tag *starr.Tag) (*starr.Tag, error) {
+	return p.AddTagContext(context.Background(), tag)
+}
+
+func (p *Prowlarr) AddTagContext(ctx context.Context, tag *starr.Tag) (*starr.Tag, error) {
+	var output starr.Tag
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(tag); err != nil {
+		return nil, fmt.Errorf("json.Marshal(tag): %w", err)
+	}
+
+	if _, err := p.PostInto(ctx, bpTag, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(tag): %w", err)
+	}
+
+	return &output, nil
+}
+
+// UpdateTag updates the tag.
+func (p *Prowlarr) UpdateTag(tag *starr.Tag) (*starr.Tag, error) {
+	return p.UpdateTagContext(context.Background(), tag)
+}
+
+func (p *Prowlarr) UpdateTagContext(ctx context.Context, tag *starr.Tag) (*starr.Tag, error) {
+	var output starr.Tag
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(tag); err != nil {
+		return nil, fmt.Errorf("json.Marshal(tag): %w", err)
+	}
+
+	uri := path.Join(bpTag, strconv.Itoa(tag.ID))
+	if _, err := p.PutInto(ctx, uri, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(tag): %w", err)
+	}
+
+	return &output, nil
 }
 
 // DeleteTag removes a single tag.
@@ -89,8 +91,8 @@ func (p *Prowlarr) DeleteTag(tagID int) error {
 }
 
 func (p *Prowlarr) DeleteTagContext(ctx context.Context, tagID int) error {
-	_, err := p.Delete(ctx, "v1/tag/"+strconv.Itoa(tagID), nil)
-	if err != nil {
+	uri := path.Join(bpTag, strconv.Itoa(tagID))
+	if _, err := p.Delete(ctx, uri, nil); err != nil {
 		return fmt.Errorf("api.Delete(tag): %w", err)
 	}
 

--- a/prowlarr/tag_test.go
+++ b/prowlarr/tag_test.go
@@ -1,0 +1,279 @@
+package prowlarr_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/prowlarr"
+)
+
+func TestGetTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		expectedResponse []*starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v1/tag",
+			responseStatus: 200,
+			responseBody:   "[{\"label\": \"epub\",\"id\": 1},{\"label\": \"4k\",\"id\": 2}]",
+			expectedResponse: []*starr.Tag{
+				{
+					Label: "epub",
+					ID:    1,
+				},
+				{
+					Label: "4k",
+					ID:    2,
+				},
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			expectedPath:     "/api/v1/tag",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetTags()
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		tagID            int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			tagID:          1,
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 200,
+			responseBody:   "{\"label\": \"epub\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "epub",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			tagID:            1,
+			expectedPath:     "/api/v1/tag/1",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetTag(test.tagID)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		tag              *starr.Tag
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v1/tag",
+			responseStatus: 200,
+			tag: &starr.Tag{
+				Label: "epub",
+			},
+			responseBody: "{\"label\": \"epub\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "epub",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			expectedPath:     "/api/v1/tag",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddTag(test.tag)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		tag              *starr.Tag
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 200,
+			tag: &starr.Tag{
+				Label: "epub",
+				ID:    1,
+			},
+			responseBody: "{\"label\": \"epub\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "epub",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:         "404",
+			expectedPath: "/api/v1/tag/1",
+			tag: &starr.Tag{
+				Label: "epub",
+				ID:    1,
+			},
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateTag(test.tag)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus int
+		tagID          int
+		name           string
+		expectedPath   string
+		responseBody   string
+		withError      error
+	}{
+		{
+			name:           "200",
+			tagID:          1,
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 200,
+			responseBody:   "{}",
+			withError:      nil,
+		},
+		{
+			name:           "404",
+			tagID:          1,
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 404,
+			responseBody:   `{"message": "NotFound"}`,
+			withError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteTag(test.tagID)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+		})
+	}
+}

--- a/radarr/tag_test.go
+++ b/radarr/tag_test.go
@@ -1,0 +1,279 @@
+package radarr_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+)
+
+func TestGetTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		expectedResponse []*starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v3/tag",
+			responseStatus: 200,
+			responseBody:   "[{\"label\": \"amzn\",\"id\": 1},{\"label\": \"netflix\",\"id\": 2}]",
+			expectedResponse: []*starr.Tag{
+				{
+					Label: "amzn",
+					ID:    1,
+				},
+				{
+					Label: "netflix",
+					ID:    2,
+				},
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			expectedPath:     "/api/v3/tag",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetTags()
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		tagID            int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			tagID:          1,
+			expectedPath:   "/api/v3/tag/1",
+			responseStatus: 200,
+			responseBody:   "{\"label\": \"amzn\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			tagID:            1,
+			expectedPath:     "/api/v3/tag/1",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetTag(test.tagID)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		tag              *starr.Tag
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v3/tag",
+			responseStatus: 200,
+			tag: &starr.Tag{
+				Label: "amzn",
+			},
+			responseBody: "{\"label\": \"amzn\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			expectedPath:     "/api/v3/tag",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddTag(test.tag)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		tag              *starr.Tag
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v3/tag/1",
+			responseStatus: 200,
+			tag: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			responseBody: "{\"label\": \"amzn\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:         "404",
+			expectedPath: "/api/v3/tag/1",
+			tag: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateTag(test.tag)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus int
+		tagID          int
+		name           string
+		expectedPath   string
+		responseBody   string
+		withError      error
+	}{
+		{
+			name:           "200",
+			tagID:          1,
+			expectedPath:   "/api/v3/tag/1",
+			responseStatus: 200,
+			responseBody:   "{}",
+			withError:      nil,
+		},
+		{
+			name:           "404",
+			tagID:          1,
+			expectedPath:   "/api/v3/tag/1",
+			responseStatus: 404,
+			responseBody:   `{"message": "NotFound"}`,
+			withError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteTag(test.tagID)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+		})
+	}
+}

--- a/readarr/tag.go
+++ b/readarr/tag.go
@@ -5,63 +5,27 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"strconv"
 
 	"golift.io/starr"
 )
 
-// GetTags returns all the tags.
+const bpTag = APIver + "/tag"
+
+// GetTags returns all configured tags.
 func (r *Readarr) GetTags() ([]*starr.Tag, error) {
 	return r.GetTagsContext(context.Background())
 }
 
 func (r *Readarr) GetTagsContext(ctx context.Context) ([]*starr.Tag, error) {
-	var tags []*starr.Tag
+	var output []*starr.Tag
 
-	_, err := r.GetInto(ctx, "v1/tag", nil, &tags)
-	if err != nil {
+	if _, err := r.GetInto(ctx, bpTag, nil, &output); err != nil {
 		return nil, fmt.Errorf("api.Get(tag): %w", err)
 	}
 
-	return tags, nil
-}
-
-// UpdateTag updates the label for a tag.
-func (r *Readarr) UpdateTag(tagID int, label string) (int, error) {
-	return r.UpdateTagContext(context.Background(), tagID, label)
-}
-
-func (r *Readarr) UpdateTagContext(ctx context.Context, tagID int, label string) (int, error) {
-	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label, ID: tagID}); err != nil {
-		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
-	}
-
-	var tag starr.Tag
-	if _, err := r.PutInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, &body, &tag); err != nil {
-		return tag.ID, fmt.Errorf("api.Put(tag): %w", err)
-	}
-
-	return tag.ID, nil
-}
-
-// AddTag adds a tag or returns the ID for an existing tag.
-func (r *Readarr) AddTag(label string) (int, error) {
-	return r.AddTagContext(context.Background(), label)
-}
-
-func (r *Readarr) AddTagContext(ctx context.Context, label string) (int, error) {
-	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(&starr.Tag{Label: label}); err != nil {
-		return 0, fmt.Errorf("json.Marshal(tag): %w", err)
-	}
-
-	var tag starr.Tag
-	if _, err := r.PostInto(ctx, "v1/tag", nil, &body, &tag); err != nil {
-		return tag.ID, fmt.Errorf("api.Post(tag): %w", err)
-	}
-
-	return tag.ID, nil
+	return output, nil
 }
 
 // GetTag returns a single tag.
@@ -70,14 +34,55 @@ func (r *Readarr) GetTag(tagID int) (*starr.Tag, error) {
 }
 
 func (r *Readarr) GetTagContext(ctx context.Context, tagID int) (*starr.Tag, error) {
-	var tag *starr.Tag
+	var output *starr.Tag
 
-	_, err := r.GetInto(ctx, "v1/tag/"+strconv.Itoa(tagID), nil, &tag)
-	if err != nil {
+	uri := path.Join(bpTag, strconv.Itoa(tagID))
+	if _, err := r.GetInto(ctx, uri, nil, &output); err != nil {
 		return nil, fmt.Errorf("api.Get(tag): %w", err)
 	}
 
-	return tag, nil
+	return output, nil
+}
+
+// AddTag creates a tag.
+func (r *Readarr) AddTag(tag *starr.Tag) (*starr.Tag, error) {
+	return r.AddTagContext(context.Background(), tag)
+}
+
+func (r *Readarr) AddTagContext(ctx context.Context, tag *starr.Tag) (*starr.Tag, error) {
+	var output starr.Tag
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(tag); err != nil {
+		return nil, fmt.Errorf("json.Marshal(tag): %w", err)
+	}
+
+	if _, err := r.PostInto(ctx, bpTag, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(tag): %w", err)
+	}
+
+	return &output, nil
+}
+
+// UpdateTag updates the tag.
+func (r *Readarr) UpdateTag(tag *starr.Tag) (*starr.Tag, error) {
+	return r.UpdateTagContext(context.Background(), tag)
+}
+
+func (r *Readarr) UpdateTagContext(ctx context.Context, tag *starr.Tag) (*starr.Tag, error) {
+	var output starr.Tag
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(tag); err != nil {
+		return nil, fmt.Errorf("json.Marshal(tag): %w", err)
+	}
+
+	uri := path.Join(bpTag, strconv.Itoa(tag.ID))
+	if _, err := r.PutInto(ctx, uri, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(tag): %w", err)
+	}
+
+	return &output, nil
 }
 
 // DeleteTag removes a single tag.
@@ -86,8 +91,8 @@ func (r *Readarr) DeleteTag(tagID int) error {
 }
 
 func (r *Readarr) DeleteTagContext(ctx context.Context, tagID int) error {
-	_, err := r.Delete(ctx, "v1/tag/"+strconv.Itoa(tagID), nil)
-	if err != nil {
+	uri := path.Join(bpTag, strconv.Itoa(tagID))
+	if _, err := r.Delete(ctx, uri, nil); err != nil {
 		return fmt.Errorf("api.Delete(tag): %w", err)
 	}
 

--- a/readarr/tag_test.go
+++ b/readarr/tag_test.go
@@ -1,0 +1,279 @@
+package readarr_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/readarr"
+)
+
+func TestGetTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		expectedResponse []*starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v1/tag",
+			responseStatus: 200,
+			responseBody:   "[{\"label\": \"amzn\",\"id\": 1},{\"label\": \"epub\",\"id\": 2}]",
+			expectedResponse: []*starr.Tag{
+				{
+					Label: "amzn",
+					ID:    1,
+				},
+				{
+					Label: "epub",
+					ID:    2,
+				},
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			expectedPath:     "/api/v1/tag",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetTags()
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		tagID            int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			tagID:          1,
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 200,
+			responseBody:   "{\"label\": \"amzn\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			tagID:            1,
+			expectedPath:     "/api/v1/tag/1",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetTag(test.tagID)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		tag              *starr.Tag
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v1/tag",
+			responseStatus: 200,
+			tag: &starr.Tag{
+				Label: "amzn",
+			},
+			responseBody: "{\"label\": \"amzn\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			expectedPath:     "/api/v1/tag",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddTag(test.tag)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		tag              *starr.Tag
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 200,
+			tag: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			responseBody: "{\"label\": \"amzn\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:         "404",
+			expectedPath: "/api/v1/tag/1",
+			tag: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateTag(test.tag)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus int
+		tagID          int
+		name           string
+		expectedPath   string
+		responseBody   string
+		withError      error
+	}{
+		{
+			name:           "200",
+			tagID:          1,
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 200,
+			responseBody:   "{}",
+			withError:      nil,
+		},
+		{
+			name:           "404",
+			tagID:          1,
+			expectedPath:   "/api/v1/tag/1",
+			responseStatus: 404,
+			responseBody:   `{"message": "NotFound"}`,
+			withError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteTag(test.tagID)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+		})
+	}
+}

--- a/sonarr/tag_test.go
+++ b/sonarr/tag_test.go
@@ -1,0 +1,279 @@
+package sonarr_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/sonarr"
+)
+
+func TestGetTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		expectedResponse []*starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v3/tag",
+			responseStatus: 200,
+			responseBody:   "[{\"label\": \"amzn\",\"id\": 1},{\"label\": \"netflix\",\"id\": 2}]",
+			expectedResponse: []*starr.Tag{
+				{
+					Label: "amzn",
+					ID:    1,
+				},
+				{
+					Label: "netflix",
+					ID:    2,
+				},
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			expectedPath:     "/api/v3/tag",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetTags()
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		tagID            int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			tagID:          1,
+			expectedPath:   "/api/v3/tag/1",
+			responseStatus: 200,
+			responseBody:   "{\"label\": \"amzn\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			tagID:            1,
+			expectedPath:     "/api/v3/tag/1",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetTag(test.tagID)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		tag              *starr.Tag
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v3/tag",
+			responseStatus: 200,
+			tag: &starr.Tag{
+				Label: "amzn",
+			},
+			responseBody: "{\"label\": \"amzn\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:             "404",
+			expectedPath:     "/api/v3/tag",
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddTag(test.tag)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus   int
+		name             string
+		expectedPath     string
+		responseBody     string
+		withError        error
+		tag              *starr.Tag
+		expectedResponse *starr.Tag
+	}{
+		{
+			name:           "200",
+			expectedPath:   "/api/v3/tag/1",
+			responseStatus: 200,
+			tag: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			responseBody: "{\"label\": \"amzn\",\"id\": 1}",
+			expectedResponse: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			withError: nil,
+		},
+		{
+			name:         "404",
+			expectedPath: "/api/v3/tag/1",
+			tag: &starr.Tag{
+				Label: "amzn",
+				ID:    1,
+			},
+			responseStatus:   404,
+			responseBody:     `{"message": "NotFound"}`,
+			withError:        starr.ErrInvalidStatusCode,
+			expectedResponse: nil,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateTag(test.tag)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.expectedResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteTag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		responseStatus int
+		tagID          int
+		name           string
+		expectedPath   string
+		responseBody   string
+		withError      error
+	}{
+		{
+			name:           "200",
+			tagID:          1,
+			expectedPath:   "/api/v3/tag/1",
+			responseStatus: 200,
+			responseBody:   "{}",
+			withError:      nil,
+		},
+		{
+			name:           "404",
+			tagID:          1,
+			expectedPath:   "/api/v3/tag/1",
+			responseStatus: 404,
+			responseBody:   `{"message": "NotFound"}`,
+			withError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteTag(test.tagID)
+			assert.ErrorIs(t, err, test.withError, "error is not the same as expected")
+		})
+	}
+}


### PR DESCRIPTION
PR for changes in tags across all clients:
- change methods output
- align naming convention for output
- use constant for base path and uri var to construct request
- add tests