### PR TITLE
build: add golangci configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+issues:
+  exclude-rules:
+    # Exclude funlen for testing files.
+    - linters:
+        - funlen
+      path: '(.+)_test\.go'
+
+linters:
+  enable-all: true
+  disable:
+    - maligned
+    - scopelint
+    - interfacer
+    - golint
+    - tagliatelle
+    - exhaustivestruct
+    - dupl
+
+run:
+  timeout: 35m

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ test: lint nopollution
 
 lint:
 	# Test lint on four platforms.
-	GOOS=linux golangci-lint run --enable-all -D maligned,scopelint,interfacer,golint,tagliatelle,exhaustivestruct,dupl
-	GOOS=darwin golangci-lint run --enable-all -D maligned,scopelint,interfacer,golint,tagliatelle,exhaustivestruct,dupl
-	GOOS=windows golangci-lint run --enable-all -D maligned,scopelint,interfacer,golint,tagliatelle,exhaustivestruct,dupl
-	GOOS=freebsd golangci-lint run --enable-all -D maligned,scopelint,interfacer,golint,tagliatelle,exhaustivestruct,dupl
+	GOOS=linux golangci-lint run
+	GOOS=darwin golangci-lint run
+	GOOS=windows golangci-lint run
+	GOOS=freebsd golangci-lint run
 
 # Some of these are borderline. For instance "edition" shows up in radarr payloads. "series" shows up in Readarr, "author" in Sonarr, etc.
 # If these catch legitimate uses, just remove the piece that caught it.

--- a/starrcmd/radarr_test.go
+++ b/starrcmd/radarr_test.go
@@ -1,4 +1,4 @@
-//nolint:paralleltest,cyclop,funlen
+//nolint:paralleltest,cyclop
 package starrcmd_test
 
 import (


### PR DESCRIPTION
- Move golang-ci configuration from command to dedicated config file.
- Disable funlen linters for test files

@davidnewhall this is mainly to avoid having multiple comments `//nolint:something` around the code.
If there is some other generic rule you want to implement, I can add them to this PR, or we can start with this and add rules only when/if needed.