### PR TITLE
feat(sonarr)!: migrate series output

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -101,7 +101,7 @@ type Tag struct {
 // Image is used in a few places.
 type Image struct {
 	CoverType string `json:"coverType"`
-	URL       string `json:"url"`
+	URL       string `json:"url,omitempty"`
 	RemoteURL string `json:"remoteUrl,omitempty"`
 	Extension string `json:"extension,omitempty"`
 }

--- a/sonarr/series.go
+++ b/sonarr/series.go
@@ -240,7 +240,8 @@ func (s *Sonarr) LookupContext(ctx context.Context, term string) ([]*Series, err
 }
 
 // DeleteSeries removes a single Series.
-// deleteFiles and importExclude flags defines the deleteFiles and addImportListExclusion query paramenters respectively.
+// deleteFiles flag defines the deleteFiles query paramenter.
+// importExclude defines the addImportListExclusion query paramenter.
 func (s *Sonarr) DeleteSeries(seriesID int, deleteFiles bool, importExclude bool) error {
 	return s.DeleteSeriesContext(context.Background(), seriesID, deleteFiles, importExclude)
 }

--- a/sonarr/series.go
+++ b/sonarr/series.go
@@ -6,10 +6,111 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"path"
 	"strconv"
+	"time"
 
 	"golift.io/starr"
 )
+
+// AddSeriesInput is the input for /api/v3/series endpoint.
+type AddSeriesInput struct {
+	Monitored         bool           `json:"monitored"`
+	SeasonFolder      bool           `json:"seasonFolder,omitempty"`
+	UseSceneNumbering bool           `json:"useSceneNumbering,omitempty"`
+	ID                int64          `json:"id,omitempty"`
+	LanguageProfileID int64          `json:"languageProfileId,omitempty"`
+	QualityProfileID  int64          `json:"qualityProfileId,omitempty"`
+	TvdbID            int64          `json:"tvdbId,omitempty"`
+	ImdbID            string         `json:"imdbId,omitempty"`
+	TvMazeID          int64          `json:"tvMazeId,omitempty"`
+	TvRageID          int64          `json:"tvRageId,omitempty"`
+	Path              string         `json:"path,omitempty"`
+	SeriesType        string         `json:"seriesType,omitempty"`
+	Title             string         `json:"title,omitempty"`
+	TitleSlug         string         `json:"titleSlug,omitempty"`
+	RootFolderPath    string         `json:"rootFolderPath,omitempty"`
+	Tags              []int          `json:"tags,omitempty"`
+	Seasons           []*Season      `json:"seasons,omitempty"`
+	Images            []*starr.Image `json:"images,omitempty"`
+	// to be used only on POST, not for PUT
+	AddOptions *AddSeriesOptions `json:"addOptions,omitempty"`
+}
+
+// Series is the output of /api/v3/series endpoint.
+type Series struct {
+	Ended             bool              `json:"ended,omitempty"`
+	Monitored         bool              `json:"monitored"`
+	SeasonFolder      bool              `json:"seasonFolder,omitempty"`
+	UseSceneNumbering bool              `json:"useSceneNumbering,omitempty"`
+	Runtime           int               `json:"runtime,omitempty"`
+	Year              int               `json:"year,omitempty"`
+	ID                int64             `json:"id,omitempty"`
+	LanguageProfileID int64             `json:"languageProfileId,omitempty"`
+	QualityProfileID  int64             `json:"qualityProfileId,omitempty"`
+	TvdbID            int64             `json:"tvdbId,omitempty"`
+	TvMazeID          int64             `json:"tvMazeId,omitempty"`
+	TvRageID          int64             `json:"tvRageId,omitempty"`
+	AirTime           string            `json:"airTime,omitempty"`
+	Certification     string            `json:"certification,omitempty"`
+	CleanTitle        string            `json:"cleanTitle,omitempty"`
+	ImdbID            string            `json:"imdbId,omitempty"`
+	Network           string            `json:"network,omitempty"`
+	Overview          string            `json:"overview,omitempty"`
+	Path              string            `json:"path,omitempty"`
+	SeriesType        string            `json:"seriesType,omitempty"`
+	SortTitle         string            `json:"sortTitle,omitempty"`
+	Status            string            `json:"status,omitempty"`
+	Title             string            `json:"title,omitempty"`
+	TitleSlug         string            `json:"titleSlug,omitempty"`
+	RootFolderPath    string            `json:"rootFolderPath,omitempty"`
+	Added             time.Time         `json:"added,omitempty"`
+	FirstAired        time.Time         `json:"firstAired,omitempty"`
+	NextAiring        time.Time         `json:"nextAiring,omitempty"`
+	PreviousAiring    time.Time         `json:"previousAiring,omitempty"`
+	Ratings           *starr.Ratings    `json:"ratings,omitempty"`
+	Statistics        *Statistics       `json:"statistics,omitempty"`
+	Tags              []int             `json:"tags,omitempty"`
+	Genres            []string          `json:"genres,omitempty"`
+	AlternateTitles   []*AlternateTitle `json:"alternateTitles,omitempty"`
+	Seasons           []*Season         `json:"seasons,omitempty"`
+	Images            []*starr.Image    `json:"images,omitempty"`
+}
+
+// AddSeriesOptions is part of AddSeriesInput.
+type AddSeriesOptions struct {
+	SearchForMissingEpisodes     bool `json:"searchForMissingEpisodes"`
+	SearchForCutoffUnmetEpisodes bool `json:"searchForCutoffUnmetEpisodes,omitempty"`
+	IgnoreEpisodesWithFiles      bool `json:"ignoreEpisodesWithFiles,omitempty"`
+	IgnoreEpisodesWithoutFiles   bool `json:"ignoreEpisodesWithoutFiles,omitempty"`
+}
+
+// AlternateTitle is part of a AddSeriesInput.
+type AlternateTitle struct {
+	SeasonNumber int    `json:"seasonNumber"`
+	Title        string `json:"title"`
+}
+
+// Season is part of AddSeriesInput and Queue and used in a few places.
+type Season struct {
+	Monitored    bool        `json:"monitored"`
+	SeasonNumber int         `json:"seasonNumber"`
+	Statistics   *Statistics `json:"statistics,omitempty"`
+}
+
+// Statistics is part of AddSeriesInput and Queue.
+type Statistics struct {
+	SeasonCount       int       `json:"seasonCount"`
+	EpisodeFileCount  int       `json:"episodeFileCount"`
+	EpisodeCount      int       `json:"episodeCount"`
+	TotalEpisodeCount int       `json:"totalEpisodeCount"`
+	SizeOnDisk        int64     `json:"sizeOnDisk"`
+	PercentOfEpisodes float64   `json:"percentOfEpisodes"`
+	PreviousAiring    time.Time `json:"previousAiring"`
+}
+
+// Define Base Path for Series calls.
+const bpSeries = APIver + "/series"
 
 // GetAllSeries returns all configured series.
 // This may not deal well with pagination atm.
@@ -27,50 +128,28 @@ func (s *Sonarr) GetSeries(tvdbID int64) ([]*Series, error) {
 }
 
 func (s *Sonarr) GetSeriesContext(ctx context.Context, tvdbID int64) ([]*Series, error) {
-	params := make(url.Values)
+	var output []*Series
 
+	params := make(url.Values)
 	if tvdbID != 0 {
 		params.Add("tvdbId", strconv.FormatInt(tvdbID, starr.Base10))
 	}
 
-	var series []*Series
-
-	_, err := s.GetInto(ctx, "v3/series", params, &series)
-	if err != nil {
-		return nil, fmt.Errorf("api.Get(series): %w", err)
+	if _, err := s.GetInto(ctx, bpSeries, params, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", bpSeries, err)
 	}
 
-	return series, nil
+	return output, nil
 }
 
 // UpdateSeries updates a series in place.
-func (s *Sonarr) UpdateSeries(seriesID int64, series *Series) error {
-	return s.UpdateSeriesContext(context.Background(), seriesID, series)
+func (s *Sonarr) UpdateSeries(series *AddSeriesInput) (*Series, error) {
+	return s.UpdateSeriesContext(context.Background(), series)
 }
 
-func (s *Sonarr) UpdateSeriesContext(ctx context.Context, seriesID int64, series *Series) error {
-	params := make(url.Values)
-	params.Add("moveFiles", "true")
+func (s *Sonarr) UpdateSeriesContext(ctx context.Context, series *AddSeriesInput) (*Series, error) {
+	var output *Series
 
-	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(series); err != nil {
-		return fmt.Errorf("json.Marshal(series): %w", err)
-	}
-
-	_, err := s.Put(ctx, "v3/series/"+strconv.FormatInt(seriesID, starr.Base10), params, &body)
-	if err != nil {
-		return fmt.Errorf("api.Put(series): %w", err)
-	}
-
-	return nil
-}
-
-// AddSeries adds a new series to Sonarr.
-func (s *Sonarr) AddSeries(series *AddSeriesInput) (*AddSeriesOutput, error) {
-	return s.AddSeriesContext(context.Background(), series)
-}
-
-func (s *Sonarr) AddSeriesContext(ctx context.Context, series *AddSeriesInput) (*AddSeriesOutput, error) {
 	params := make(url.Values)
 	params.Add("moveFiles", "true")
 
@@ -79,9 +158,32 @@ func (s *Sonarr) AddSeriesContext(ctx context.Context, series *AddSeriesInput) (
 		return nil, fmt.Errorf("json.Marshal(series): %w", err)
 	}
 
-	var output AddSeriesOutput
-	if _, err := s.PostInto(ctx, "v3/series", params, &body, &output); err != nil {
-		return nil, fmt.Errorf("api.Post(series): %w", err)
+	uri := path.Join(bpSeries, strconv.Itoa(int(series.ID)))
+	if _, err := s.PutInto(ctx, uri, params, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", uri, err)
+	}
+
+	return output, nil
+}
+
+// AddSeries adds a new series to Sonarr.
+func (s *Sonarr) AddSeries(series *AddSeriesInput) (*Series, error) {
+	return s.AddSeriesContext(context.Background(), series)
+}
+
+func (s *Sonarr) AddSeriesContext(ctx context.Context, series *AddSeriesInput) (*Series, error) {
+	var output Series
+
+	params := make(url.Values)
+	params.Add("moveFiles", "true")
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(series); err != nil {
+		return nil, fmt.Errorf("json.Marshal(series): %w", err)
+	}
+
+	if _, err := s.PostInto(ctx, bpSeries, params, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", bpSeries, err)
 	}
 
 	return &output, nil
@@ -93,14 +195,14 @@ func (s *Sonarr) GetSeriesByID(seriesID int64) (*Series, error) {
 }
 
 func (s *Sonarr) GetSeriesByIDContext(ctx context.Context, seriesID int64) (*Series, error) {
-	var series Series
+	var output Series
 
-	_, err := s.GetInto(ctx, "v3/series/"+strconv.FormatInt(seriesID, starr.Base10), nil, &series)
-	if err != nil {
-		return nil, fmt.Errorf("api.Get(series): %w", err)
+	uri := path.Join(bpSeries, strconv.Itoa(int(seriesID)))
+	if _, err := s.GetInto(ctx, uri, nil, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", uri, err)
 	}
 
-	return &series, nil
+	return &output, nil
 }
 
 // GetSeriesLookup searches for a series [in Servarr] using a search term or a tvdbid.
@@ -110,22 +212,21 @@ func (s *Sonarr) GetSeriesLookup(term string, tvdbID int64) ([]*Series, error) {
 }
 
 func (s *Sonarr) GetSeriesLookupContext(ctx context.Context, term string, tvdbID int64) ([]*Series, error) {
-	params := make(url.Values)
+	var output []*Series
 
+	params := make(url.Values)
 	if tvdbID > 0 {
 		params.Add("term", "tvdbid:"+strconv.FormatInt(tvdbID, starr.Base10))
 	} else {
 		params.Add("term", term)
 	}
 
-	var series []*Series
-
-	_, err := s.GetInto(ctx, "v3/series/lookup", params, &series)
-	if err != nil {
-		return nil, fmt.Errorf("api.Get(series/lookup): %w", err)
+	uri := path.Join(bpSeries, "lookup")
+	if _, err := s.GetInto(ctx, uri, params, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", uri, err)
 	}
 
-	return series, nil
+	return output, nil
 }
 
 // Lookup will search for series matching the specified search term.
@@ -136,4 +237,28 @@ func (s *Sonarr) Lookup(term string) ([]*Series, error) {
 
 func (s *Sonarr) LookupContext(ctx context.Context, term string) ([]*Series, error) {
 	return s.GetSeriesLookupContext(ctx, term, 0)
+}
+
+// DeleteSeries removes a single Series.
+// deleteFiles and importExclude flags defines the deleteFiles and addImportListExclusion query paramenters respectively.
+func (s *Sonarr) DeleteSeries(seriesID int, deleteFiles bool, importExclude bool) error {
+	return s.DeleteSeriesContext(context.Background(), seriesID, deleteFiles, importExclude)
+}
+
+func (s *Sonarr) DeleteSeriesContext(ctx context.Context, seriesID int, deleteFiles bool, importExclude bool) error {
+	params := make(url.Values)
+	params.Add("deleteFiles", strconv.FormatBool(deleteFiles))
+	params.Add("addImportListExclusion", strconv.FormatBool(importExclude))
+
+	uri := path.Join(bpSeries, strconv.Itoa(seriesID))
+	if _, err := s.Delete(ctx, uri, params); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", uri, err)
+	}
+
+	return nil
+}
+
+// DeleteSeriesDefault defines the behaviour to set deleteFiles to true and addImportListExclusion to false.
+func (s *Sonarr) DeleteSeriesDefault(seriesID int) error {
+	return s.DeleteSeriesContext(context.Background(), seriesID, true, false)
 }

--- a/sonarr/series_test.go
+++ b/sonarr/series_test.go
@@ -1,0 +1,1665 @@
+package sonarr_test
+
+import (
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/sonarr"
+)
+
+const (
+	firstSeries = `{
+	"title": "Breaking Bad",
+	"alternateTitles": [],
+	"sortTitle": "breaking bad",
+	"status": "ended",
+	"ended": true,
+	"overview": "Cool teacher becomes drug dealer",
+	"previousAiring": "2019-06-04T01:00:00Z",
+	"network": "Netflix",
+	"airTime": "21:00",
+	"images": [
+		{
+			"coverType": "banner",
+			"url": "/MediaCover/1/banner.jpg?lastWrite=637829401993017870",
+			"remoteUrl": "https://artworks.thetvdb.com/banners/graphical/81189-g21.jpg"
+		},
+		{
+			"coverType": "poster",
+			"url": "/MediaCover/1/poster.jpg?lastWrite=637829401994817870",
+			"remoteUrl": "https://artworks.thetvdb.com/banners/posters/81189-10.jpg"
+		},
+		{
+			"coverType": "fanart",
+			"url": "/MediaCover/1/fanart.jpg?lastWrite=637829401996517870",
+			"remoteUrl": "https://artworks.thetvdb.com/banners/fanart/original/81189-21.jpg"
+		}
+	],
+	"seasons": [
+		{
+			"seasonNumber": 0,
+			"monitored": false,
+			"statistics": {
+				"episodeFileCount": 0,
+				"episodeCount": 0,
+				"totalEpisodeCount": 19,
+				"sizeOnDisk": 0,
+				"percentOfEpisodes": 0.0
+			}
+		},
+		{
+			"seasonNumber": 1,
+			"monitored": true,
+			"statistics": {
+				"previousAiring": "2019-06-04T01:00:00Z",
+				"episodeFileCount": 0,
+				"episodeCount": 7,
+				"totalEpisodeCount": 7,
+				"sizeOnDisk": 0,
+				"percentOfEpisodes": 0.0
+			}
+		},
+		{
+			"seasonNumber": 2,
+			"monitored": true,
+			"statistics": {
+				"previousAiring": "2019-06-04T01:00:00Z",
+				"episodeFileCount": 0,
+				"episodeCount": 13,
+				"totalEpisodeCount": 13,
+				"sizeOnDisk": 0,
+				"percentOfEpisodes": 0.0
+			}
+		},
+		{
+			"seasonNumber": 3,
+			"monitored": true,
+			"statistics": {
+				"previousAiring": "2019-06-04T01:00:00Z",
+				"episodeFileCount": 0,
+				"episodeCount": 13,
+				"totalEpisodeCount": 13,
+				"sizeOnDisk": 0,
+				"percentOfEpisodes": 0.0
+			}
+		},
+		{
+			"seasonNumber": 4,
+			"monitored": true,
+			"statistics": {
+				"previousAiring": "2019-06-04T01:00:00Z",
+				"episodeFileCount": 0,
+				"episodeCount": 13,
+				"totalEpisodeCount": 13,
+				"sizeOnDisk": 0,
+				"percentOfEpisodes": 0.0
+			}
+		},
+		{
+			"seasonNumber": 5,
+			"monitored": true,
+			"statistics": {
+				"previousAiring": "2019-06-04T01:00:00Z",
+				"episodeFileCount": 0,
+				"episodeCount": 16,
+				"totalEpisodeCount": 16,
+				"sizeOnDisk": 0,
+				"percentOfEpisodes": 0.0
+			}
+		}
+	],
+	"year": 2008,
+	"path": "/series/Breaking Bad",
+	"qualityProfileId": 1,
+	"languageProfileId": 1,
+	"seasonFolder": true,
+	"monitored": true,
+	"useSceneNumbering": false,
+	"runtime": 47,
+	"tvdbId": 81189,
+	"tvRageId": 18164,
+	"tvMazeId": 169,
+	"firstAired": "2019-06-04T01:00:00Z",
+	"seriesType": "standard",
+	"cleanTitle": "breakingbad",
+	"imdbId": "tt0903747",
+	"titleSlug": "breaking-bad",
+	"rootFolderPath": "/series/",
+	"certification": "TV-MA",
+	"genres": [
+		"Crime",
+		"Drama",
+		"Suspense",
+		"Thriller"
+	],
+	"tags": [
+		11
+	],
+	"added": "2019-06-04T01:00:00Z",
+	"ratings": {
+		"votes": 31714,
+		"value": 9.4
+	},
+	"statistics": {
+		"seasonCount": 5,
+		"episodeFileCount": 0,
+		"episodeCount": 62,
+		"totalEpisodeCount": 81,
+		"sizeOnDisk": 0,
+		"percentOfEpisodes": 0.0
+	},
+	"id": 1
+}`
+	secondSeries = `{
+	"title": "Chernobyl",
+	"alternateTitles": [],
+	"sortTitle": "chernobyl",
+	"status": "ended",
+	"ended": true,
+	"overview": "A lot of energy wasted",
+	"previousAiring": "2019-06-04T01:00:00Z",
+	"network": "HBO",
+	"airTime": "21:00",
+	"images": [
+		{
+			"coverType": "banner",
+			"url": "/MediaCover/2/banner.jpg?lastWrite=637829402715717870",
+			"remoteUrl": "https://artworks.thetvdb.com/banners/graphical/5cc9f74c2ddd3.jpg"
+		},
+		{
+			"coverType": "poster",
+			"url": "/MediaCover/2/poster.jpg?lastWrite=637829402718117870",
+			"remoteUrl": "https://artworks.thetvdb.com/banners/posters/5cc12861c93e4.jpg"
+		},
+		{
+			"coverType": "fanart",
+			"url": "/MediaCover/2/fanart.jpg?lastWrite=637829402721317870",
+			"remoteUrl": "https://artworks.thetvdb.com/banners/series/360893/backgrounds/62017319.jpg"
+		}
+	],
+	"seasons": [
+		{
+			"seasonNumber": 0,
+			"monitored": false,
+			"statistics": {
+				"episodeFileCount": 0,
+				"episodeCount": 0,
+				"totalEpisodeCount": 14,
+				"sizeOnDisk": 0,
+				"percentOfEpisodes": 0.0
+			}
+		},
+		{
+			"seasonNumber": 1,
+			"monitored": true,
+			"statistics": {
+				"previousAiring": "2019-06-04T01:00:00Z",
+				"episodeFileCount": 0,
+				"episodeCount": 5,
+				"totalEpisodeCount": 5,
+				"sizeOnDisk": 0,
+				"percentOfEpisodes": 0.0
+			}
+		}
+	],
+	"year": 2019,
+	"path": "/series/Chernobyl",
+	"qualityProfileId": 1,
+	"languageProfileId": 1,
+	"seasonFolder": true,
+	"monitored": true,
+	"useSceneNumbering": false,
+	"runtime": 65,
+	"tvdbId": 360893,
+	"tvRageId": 0,
+	"tvMazeId": 30770,
+	"firstAired": "2019-06-04T01:00:00Z",
+	"seriesType": "standard",
+	"cleanTitle": "chernobyl",
+	"imdbId": "tt7366338",
+	"titleSlug": "chernobyl",
+	"rootFolderPath": "/series/",
+	"certification": "TV-MA",
+	"genres": [
+		"Drama",
+		"History",
+		"Mini-Series",
+		"Thriller"
+	],
+	"tags": [
+		11
+	],
+	"added": "2019-06-04T01:00:00Z",
+	"ratings": {
+		"votes": 83,
+		"value": 8.7
+	},
+	"statistics": {
+		"seasonCount": 1,
+		"episodeFileCount": 0,
+		"episodeCount": 5,
+		"totalEpisodeCount": 19,
+		"sizeOnDisk": 0,
+		"percentOfEpisodes": 0.0
+	},
+	"id": 2
+}`
+	listSeries = `[` + firstSeries + `,` + secondSeries + `]`
+	addSeries  = `{"monitored":true,"seasonFolder":true,"languageProfileId":1,"qualityProfileId":1,` +
+		`"tvdbId":360893,"path":"/series/Chernobyl","title":"Chernobyl","titleSlug":"chernobyl",` +
+		`"rootFolderPath":"/series/","tags":[11],` +
+		`"seasons":[{"monitored":false,"seasonNumber":0},{"monitored":true,"seasonNumber":1}],` +
+		`"images":[{"coverType":"banner","remoteUrl":"https://artworks.thetvdb.com/banners/graphical/5cc9f74c2ddd3.jpg"},` +
+		`{"coverType":"poster","remoteUrl":"https://artworks.thetvdb.com/banners/posters/5cc12861c93e4.jpg"},` +
+		`{"coverType":"fanart","remoteUrl":"https://artworks.thetvdb.com/banners/series/360893/backgrounds/62017319.jpg"}],` +
+		`"addOptions":{"searchForMissingEpisodes":true}}` +
+		"\n"
+	updateSeries = `{"monitored":true,"seasonFolder":true,"id":1,"languageProfileId":1,"qualityProfileId":1,` +
+		`"tvdbId":360893,"path":"/series/Chernobyl","title":"Chernobyl","rootFolderPath":` +
+		`"/series/","tags":[11],"seasons":[{"monitored":false,"seasonNumber":0},{"monitored":true,"seasonNumber":1}]}` +
+		"\n"
+)
+
+func TestGetAllSeries(t *testing.T) {
+	t.Parallel()
+
+	loc, _ := time.LoadLocation("")
+	date := time.Date(2019, 6, 4, 1, 0, 0, 0, loc)
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   listSeries,
+			WithResponse: []*sonarr.Series{
+				{
+					Title:           "Breaking Bad",
+					AlternateTitles: []*sonarr.AlternateTitle{},
+					SortTitle:       "breaking bad",
+					Status:          "ended",
+					Ended:           true,
+					Overview:        "Cool teacher becomes drug dealer",
+					PreviousAiring:  date,
+					Network:         "Netflix",
+					AirTime:         "21:00",
+					Images: []*starr.Image{
+						{
+							CoverType: "banner",
+							URL:       "/MediaCover/1/banner.jpg?lastWrite=637829401993017870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/graphical/81189-g21.jpg",
+						},
+						{
+							CoverType: "poster",
+							URL:       "/MediaCover/1/poster.jpg?lastWrite=637829401994817870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/posters/81189-10.jpg",
+						},
+						{
+							CoverType: "fanart",
+							URL:       "/MediaCover/1/fanart.jpg?lastWrite=637829401996517870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/fanart/original/81189-21.jpg",
+						},
+					},
+					Seasons: []*sonarr.Season{
+						{
+							SeasonNumber: 0,
+							Monitored:    false,
+							Statistics: &sonarr.Statistics{
+								EpisodeFileCount:  0,
+								EpisodeCount:      0,
+								TotalEpisodeCount: 19,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 1,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      7,
+								TotalEpisodeCount: 7,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 2,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      13,
+								TotalEpisodeCount: 13,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 3,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      13,
+								TotalEpisodeCount: 13,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 4,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      13,
+								TotalEpisodeCount: 13,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 5,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      16,
+								TotalEpisodeCount: 16,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+					},
+					Year:              2008,
+					Path:              "/series/Breaking Bad",
+					QualityProfileID:  1,
+					LanguageProfileID: 1,
+					SeasonFolder:      true,
+					Monitored:         true,
+					UseSceneNumbering: false,
+					Runtime:           47,
+					TvdbID:            81189,
+					TvRageID:          18164,
+					TvMazeID:          169,
+					FirstAired:        date,
+					SeriesType:        "standard",
+					CleanTitle:        "breakingbad",
+					ImdbID:            "tt0903747",
+					TitleSlug:         "breaking-bad",
+					RootFolderPath:    "/series/",
+					Certification:     "TV-MA",
+					Genres: []string{
+						"Crime",
+						"Drama",
+						"Suspense",
+						"Thriller",
+					},
+					Tags: []int{
+						11,
+					},
+					Added: date,
+					Ratings: &starr.Ratings{
+						Votes: 31714,
+						Value: 9.4,
+					},
+					Statistics: &sonarr.Statistics{
+						SeasonCount:       5,
+						EpisodeFileCount:  0,
+						EpisodeCount:      62,
+						TotalEpisodeCount: 81,
+						SizeOnDisk:        0,
+						PercentOfEpisodes: 0.0,
+					},
+					ID: 1,
+				},
+				{
+					Title:           "Chernobyl",
+					AlternateTitles: []*sonarr.AlternateTitle{},
+					SortTitle:       "chernobyl",
+					Status:          "ended",
+					Ended:           true,
+					Overview:        "A lot of energy wasted",
+					PreviousAiring:  date,
+					Network:         "HBO",
+					AirTime:         "21:00",
+					Images: []*starr.Image{
+						{
+							CoverType: "banner",
+							URL:       "/MediaCover/2/banner.jpg?lastWrite=637829402715717870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/graphical/5cc9f74c2ddd3.jpg",
+						},
+						{
+							CoverType: "poster",
+							URL:       "/MediaCover/2/poster.jpg?lastWrite=637829402718117870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/posters/5cc12861c93e4.jpg",
+						},
+						{
+							CoverType: "fanart",
+							URL:       "/MediaCover/2/fanart.jpg?lastWrite=637829402721317870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/series/360893/backgrounds/62017319.jpg",
+						},
+					},
+					Seasons: []*sonarr.Season{
+						{
+							SeasonNumber: 0,
+							Monitored:    false,
+							Statistics: &sonarr.Statistics{
+								EpisodeFileCount:  0,
+								EpisodeCount:      0,
+								TotalEpisodeCount: 14,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 1,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      5,
+								TotalEpisodeCount: 5,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+					},
+					Year:              2019,
+					Path:              "/series/Chernobyl",
+					QualityProfileID:  1,
+					LanguageProfileID: 1,
+					SeasonFolder:      true,
+					Monitored:         true,
+					UseSceneNumbering: false,
+					Runtime:           65,
+					TvdbID:            360893,
+					TvRageID:          0,
+					TvMazeID:          30770,
+					FirstAired:        date,
+					SeriesType:        "standard",
+					CleanTitle:        "chernobyl",
+					ImdbID:            "tt7366338",
+					TitleSlug:         "chernobyl",
+					RootFolderPath:    "/series/",
+					Certification:     "TV-MA",
+					Genres: []string{
+						"Drama",
+						"History",
+						"Mini-Series",
+						"Thriller",
+					},
+					Tags: []int{
+						11,
+					},
+					Added: date,
+					Ratings: &starr.Ratings{
+						Votes: 83,
+						Value: 8.7,
+					},
+					Statistics: &sonarr.Statistics{
+						SeasonCount:       1,
+						EpisodeFileCount:  0,
+						EpisodeCount:      5,
+						TotalEpisodeCount: 19,
+						SizeOnDisk:        0,
+						PercentOfEpisodes: 0.0,
+					},
+					ID: 2,
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   starr.BodyNotFound,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   []*sonarr.Series(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetAllSeries()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetSeries(t *testing.T) {
+	t.Parallel()
+
+	loc, _ := time.LoadLocation("")
+	date := time.Date(2019, 6, 4, 1, 0, 0, 0, loc)
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series?tvdbId=360893"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   "[" + secondSeries + "]",
+			WithRequest:    360893,
+			WithResponse: []*sonarr.Series{
+				{
+					Title:           "Chernobyl",
+					AlternateTitles: []*sonarr.AlternateTitle{},
+					SortTitle:       "chernobyl",
+					Status:          "ended",
+					Ended:           true,
+					Overview:        "A lot of energy wasted",
+					PreviousAiring:  date,
+					Network:         "HBO",
+					AirTime:         "21:00",
+					Images: []*starr.Image{
+						{
+							CoverType: "banner",
+							URL:       "/MediaCover/2/banner.jpg?lastWrite=637829402715717870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/graphical/5cc9f74c2ddd3.jpg",
+						},
+						{
+							CoverType: "poster",
+							URL:       "/MediaCover/2/poster.jpg?lastWrite=637829402718117870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/posters/5cc12861c93e4.jpg",
+						},
+						{
+							CoverType: "fanart",
+							URL:       "/MediaCover/2/fanart.jpg?lastWrite=637829402721317870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/series/360893/backgrounds/62017319.jpg",
+						},
+					},
+					Seasons: []*sonarr.Season{
+						{
+							SeasonNumber: 0,
+							Monitored:    false,
+							Statistics: &sonarr.Statistics{
+								EpisodeFileCount:  0,
+								EpisodeCount:      0,
+								TotalEpisodeCount: 14,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 1,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      5,
+								TotalEpisodeCount: 5,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+					},
+					Year:              2019,
+					Path:              "/series/Chernobyl",
+					QualityProfileID:  1,
+					LanguageProfileID: 1,
+					SeasonFolder:      true,
+					Monitored:         true,
+					UseSceneNumbering: false,
+					Runtime:           65,
+					TvdbID:            360893,
+					TvRageID:          0,
+					TvMazeID:          30770,
+					FirstAired:        date,
+					SeriesType:        "standard",
+					CleanTitle:        "chernobyl",
+					ImdbID:            "tt7366338",
+					TitleSlug:         "chernobyl",
+					RootFolderPath:    "/series/",
+					Certification:     "TV-MA",
+					Genres: []string{
+						"Drama",
+						"History",
+						"Mini-Series",
+						"Thriller",
+					},
+					Tags: []int{
+						11,
+					},
+					Added: date,
+					Ratings: &starr.Ratings{
+						Votes: 83,
+						Value: 8.7,
+					},
+					Statistics: &sonarr.Statistics{
+						SeasonCount:       1,
+						EpisodeFileCount:  0,
+						EpisodeCount:      5,
+						TotalEpisodeCount: 19,
+						SizeOnDisk:        0,
+						PercentOfEpisodes: 0.0,
+					},
+					ID: 2,
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series?tvdbId=360893"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   starr.BodyNotFound,
+			WithRequest:    360893,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   []*sonarr.Series(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetSeries(int64(test.WithRequest.(int)))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetSeriesByID(t *testing.T) {
+	t.Parallel()
+
+	loc, _ := time.LoadLocation("")
+	date := time.Date(2019, 6, 4, 1, 0, 0, 0, loc)
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series/2"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   secondSeries,
+			WithRequest:    2,
+			WithResponse: &sonarr.Series{
+				Title:           "Chernobyl",
+				AlternateTitles: []*sonarr.AlternateTitle{},
+				SortTitle:       "chernobyl",
+				Status:          "ended",
+				Ended:           true,
+				Overview:        "A lot of energy wasted",
+				PreviousAiring:  date,
+				Network:         "HBO",
+				AirTime:         "21:00",
+				Images: []*starr.Image{
+					{
+						CoverType: "banner",
+						URL:       "/MediaCover/2/banner.jpg?lastWrite=637829402715717870",
+						RemoteURL: "https://artworks.thetvdb.com/banners/graphical/5cc9f74c2ddd3.jpg",
+					},
+					{
+						CoverType: "poster",
+						URL:       "/MediaCover/2/poster.jpg?lastWrite=637829402718117870",
+						RemoteURL: "https://artworks.thetvdb.com/banners/posters/5cc12861c93e4.jpg",
+					},
+					{
+						CoverType: "fanart",
+						URL:       "/MediaCover/2/fanart.jpg?lastWrite=637829402721317870",
+						RemoteURL: "https://artworks.thetvdb.com/banners/series/360893/backgrounds/62017319.jpg",
+					},
+				},
+				Seasons: []*sonarr.Season{
+					{
+						SeasonNumber: 0,
+						Monitored:    false,
+						Statistics: &sonarr.Statistics{
+							EpisodeFileCount:  0,
+							EpisodeCount:      0,
+							TotalEpisodeCount: 14,
+							SizeOnDisk:        0,
+							PercentOfEpisodes: 0.0,
+						},
+					},
+					{
+						SeasonNumber: 1,
+						Monitored:    true,
+						Statistics: &sonarr.Statistics{
+							PreviousAiring:    date,
+							EpisodeFileCount:  0,
+							EpisodeCount:      5,
+							TotalEpisodeCount: 5,
+							SizeOnDisk:        0,
+							PercentOfEpisodes: 0.0,
+						},
+					},
+				},
+				Year:              2019,
+				Path:              "/series/Chernobyl",
+				QualityProfileID:  1,
+				LanguageProfileID: 1,
+				SeasonFolder:      true,
+				Monitored:         true,
+				UseSceneNumbering: false,
+				Runtime:           65,
+				TvdbID:            360893,
+				TvRageID:          0,
+				TvMazeID:          30770,
+				FirstAired:        date,
+				SeriesType:        "standard",
+				CleanTitle:        "chernobyl",
+				ImdbID:            "tt7366338",
+				TitleSlug:         "chernobyl",
+				RootFolderPath:    "/series/",
+				Certification:     "TV-MA",
+				Genres: []string{
+					"Drama",
+					"History",
+					"Mini-Series",
+					"Thriller",
+				},
+				Tags: []int{
+					11,
+				},
+				Added: date,
+				Ratings: &starr.Ratings{
+					Votes: 83,
+					Value: 8.7,
+				},
+				Statistics: &sonarr.Statistics{
+					SeasonCount:       1,
+					EpisodeFileCount:  0,
+					EpisodeCount:      5,
+					TotalEpisodeCount: 19,
+					SizeOnDisk:        0,
+					PercentOfEpisodes: 0.0,
+				},
+				ID: 2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series/2"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   starr.BodyNotFound,
+			WithRequest:    2,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*sonarr.Series)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetSeriesByID(int64(test.WithRequest.(int)))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddSeries(t *testing.T) {
+	t.Parallel()
+
+	loc, _ := time.LoadLocation("")
+	date := time.Date(2019, 6, 4, 1, 0, 0, 0, loc)
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, sonarr.APIver, "series?moveFiles=true"),
+			ExpectedMethod:  "POST",
+			ExpectedRequest: addSeries,
+			ResponseStatus:  200,
+			WithRequest: &sonarr.AddSeriesInput{
+				Title: "Chernobyl",
+				Images: []*starr.Image{
+					{
+						CoverType: "banner",
+						RemoteURL: "https://artworks.thetvdb.com/banners/graphical/5cc9f74c2ddd3.jpg",
+					},
+					{
+						CoverType: "poster",
+						RemoteURL: "https://artworks.thetvdb.com/banners/posters/5cc12861c93e4.jpg",
+					},
+					{
+						CoverType: "fanart",
+						RemoteURL: "https://artworks.thetvdb.com/banners/series/360893/backgrounds/62017319.jpg",
+					},
+				},
+				Seasons: []*sonarr.Season{
+					{
+						SeasonNumber: 0,
+						Monitored:    false,
+					},
+					{
+						SeasonNumber: 1,
+						Monitored:    true,
+					},
+				},
+				Path:              "/series/Chernobyl",
+				QualityProfileID:  1,
+				LanguageProfileID: 1,
+				SeasonFolder:      true,
+				Monitored:         true,
+				TvdbID:            360893,
+				TitleSlug:         "chernobyl",
+				RootFolderPath:    "/series/",
+				Tags: []int{
+					11,
+				},
+				AddOptions: &sonarr.AddSeriesOptions{
+					SearchForMissingEpisodes: true,
+				},
+			},
+			ResponseBody: secondSeries,
+			WithResponse: &sonarr.Series{
+				Title:           "Chernobyl",
+				AlternateTitles: []*sonarr.AlternateTitle{},
+				SortTitle:       "chernobyl",
+				Status:          "ended",
+				Ended:           true,
+				Overview:        "A lot of energy wasted",
+				PreviousAiring:  date,
+				Network:         "HBO",
+				AirTime:         "21:00",
+				Images: []*starr.Image{
+					{
+						CoverType: "banner",
+						URL:       "/MediaCover/2/banner.jpg?lastWrite=637829402715717870",
+						RemoteURL: "https://artworks.thetvdb.com/banners/graphical/5cc9f74c2ddd3.jpg",
+					},
+					{
+						CoverType: "poster",
+						URL:       "/MediaCover/2/poster.jpg?lastWrite=637829402718117870",
+						RemoteURL: "https://artworks.thetvdb.com/banners/posters/5cc12861c93e4.jpg",
+					},
+					{
+						CoverType: "fanart",
+						URL:       "/MediaCover/2/fanart.jpg?lastWrite=637829402721317870",
+						RemoteURL: "https://artworks.thetvdb.com/banners/series/360893/backgrounds/62017319.jpg",
+					},
+				},
+				Seasons: []*sonarr.Season{
+					{
+						SeasonNumber: 0,
+						Monitored:    false,
+						Statistics: &sonarr.Statistics{
+							EpisodeFileCount:  0,
+							EpisodeCount:      0,
+							TotalEpisodeCount: 14,
+							SizeOnDisk:        0,
+							PercentOfEpisodes: 0.0,
+						},
+					},
+					{
+						SeasonNumber: 1,
+						Monitored:    true,
+						Statistics: &sonarr.Statistics{
+							PreviousAiring:    date,
+							EpisodeFileCount:  0,
+							EpisodeCount:      5,
+							TotalEpisodeCount: 5,
+							SizeOnDisk:        0,
+							PercentOfEpisodes: 0.0,
+						},
+					},
+				},
+				Year:              2019,
+				Path:              "/series/Chernobyl",
+				QualityProfileID:  1,
+				LanguageProfileID: 1,
+				SeasonFolder:      true,
+				Monitored:         true,
+				UseSceneNumbering: false,
+				Runtime:           65,
+				TvdbID:            360893,
+				TvRageID:          0,
+				TvMazeID:          30770,
+				FirstAired:        date,
+				SeriesType:        "standard",
+				CleanTitle:        "chernobyl",
+				ImdbID:            "tt7366338",
+				TitleSlug:         "chernobyl",
+				RootFolderPath:    "/series/",
+				Certification:     "TV-MA",
+				Genres: []string{
+					"Drama",
+					"History",
+					"Mini-Series",
+					"Thriller",
+				},
+				Tags: []int{
+					11,
+				},
+				Added: date,
+				Ratings: &starr.Ratings{
+					Votes: 83,
+					Value: 8.7,
+				},
+				Statistics: &sonarr.Statistics{
+					SeasonCount:       1,
+					EpisodeFileCount:  0,
+					EpisodeCount:      5,
+					TotalEpisodeCount: 19,
+					SizeOnDisk:        0,
+					PercentOfEpisodes: 0.0,
+				},
+				ID: 2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:            "404",
+			ExpectedPath:    path.Join("/", starr.API, sonarr.APIver, "series?moveFiles=true"),
+			ExpectedMethod:  "POST",
+			ExpectedRequest: addSeries,
+			ResponseStatus:  404,
+			WithRequest: &sonarr.AddSeriesInput{
+				Title: "Chernobyl",
+				Images: []*starr.Image{
+					{
+						CoverType: "banner",
+						RemoteURL: "https://artworks.thetvdb.com/banners/graphical/5cc9f74c2ddd3.jpg",
+					},
+					{
+						CoverType: "poster",
+						RemoteURL: "https://artworks.thetvdb.com/banners/posters/5cc12861c93e4.jpg",
+					},
+					{
+						CoverType: "fanart",
+						RemoteURL: "https://artworks.thetvdb.com/banners/series/360893/backgrounds/62017319.jpg",
+					},
+				},
+				Seasons: []*sonarr.Season{
+					{
+						SeasonNumber: 0,
+						Monitored:    false,
+					},
+					{
+						SeasonNumber: 1,
+						Monitored:    true,
+					},
+				},
+				Path:              "/series/Chernobyl",
+				QualityProfileID:  1,
+				LanguageProfileID: 1,
+				SeasonFolder:      true,
+				Monitored:         true,
+				TvdbID:            360893,
+				TitleSlug:         "chernobyl",
+				RootFolderPath:    "/series/",
+				Tags: []int{
+					11,
+				},
+				AddOptions: &sonarr.AddSeriesOptions{
+					SearchForMissingEpisodes: true,
+				},
+			},
+			ResponseBody: starr.BodyNotFound,
+			WithError:    starr.ErrInvalidStatusCode,
+			WithResponse: (*sonarr.Series)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddSeries(test.WithRequest.(*sonarr.AddSeriesInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateSeries(t *testing.T) {
+	t.Parallel()
+
+	loc, _ := time.LoadLocation("")
+	date := time.Date(2019, 6, 4, 1, 0, 0, 0, loc)
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, sonarr.APIver, "series/1?moveFiles=true"),
+			ExpectedMethod:  "PUT",
+			ExpectedRequest: updateSeries,
+			ResponseStatus:  200,
+			WithRequest: &sonarr.AddSeriesInput{
+				Title: "Chernobyl",
+				Seasons: []*sonarr.Season{
+					{
+						SeasonNumber: 0,
+						Monitored:    false,
+					},
+					{
+						SeasonNumber: 1,
+						Monitored:    true,
+					},
+				},
+				Path:              "/series/Chernobyl",
+				QualityProfileID:  1,
+				LanguageProfileID: 1,
+				SeasonFolder:      true,
+				Monitored:         true,
+				TvdbID:            360893,
+				RootFolderPath:    "/series/",
+				Tags: []int{
+					11,
+				},
+				ID: 1,
+			},
+			ResponseBody: secondSeries,
+			WithResponse: &sonarr.Series{
+				Title:           "Chernobyl",
+				AlternateTitles: []*sonarr.AlternateTitle{},
+				SortTitle:       "chernobyl",
+				Status:          "ended",
+				Ended:           true,
+				Overview:        "A lot of energy wasted",
+				PreviousAiring:  date,
+				Network:         "HBO",
+				AirTime:         "21:00",
+				Images: []*starr.Image{
+					{
+						CoverType: "banner",
+						URL:       "/MediaCover/2/banner.jpg?lastWrite=637829402715717870",
+						RemoteURL: "https://artworks.thetvdb.com/banners/graphical/5cc9f74c2ddd3.jpg",
+					},
+					{
+						CoverType: "poster",
+						URL:       "/MediaCover/2/poster.jpg?lastWrite=637829402718117870",
+						RemoteURL: "https://artworks.thetvdb.com/banners/posters/5cc12861c93e4.jpg",
+					},
+					{
+						CoverType: "fanart",
+						URL:       "/MediaCover/2/fanart.jpg?lastWrite=637829402721317870",
+						RemoteURL: "https://artworks.thetvdb.com/banners/series/360893/backgrounds/62017319.jpg",
+					},
+				},
+				Seasons: []*sonarr.Season{
+					{
+						SeasonNumber: 0,
+						Monitored:    false,
+						Statistics: &sonarr.Statistics{
+							EpisodeFileCount:  0,
+							EpisodeCount:      0,
+							TotalEpisodeCount: 14,
+							SizeOnDisk:        0,
+							PercentOfEpisodes: 0.0,
+						},
+					},
+					{
+						SeasonNumber: 1,
+						Monitored:    true,
+						Statistics: &sonarr.Statistics{
+							PreviousAiring:    date,
+							EpisodeFileCount:  0,
+							EpisodeCount:      5,
+							TotalEpisodeCount: 5,
+							SizeOnDisk:        0,
+							PercentOfEpisodes: 0.0,
+						},
+					},
+				},
+				Year:              2019,
+				Path:              "/series/Chernobyl",
+				QualityProfileID:  1,
+				LanguageProfileID: 1,
+				SeasonFolder:      true,
+				Monitored:         true,
+				UseSceneNumbering: false,
+				Runtime:           65,
+				TvdbID:            360893,
+				TvRageID:          0,
+				TvMazeID:          30770,
+				FirstAired:        date,
+				SeriesType:        "standard",
+				CleanTitle:        "chernobyl",
+				ImdbID:            "tt7366338",
+				TitleSlug:         "chernobyl",
+				RootFolderPath:    "/series/",
+				Certification:     "TV-MA",
+				Genres: []string{
+					"Drama",
+					"History",
+					"Mini-Series",
+					"Thriller",
+				},
+				Tags: []int{
+					11,
+				},
+				Added: date,
+				Ratings: &starr.Ratings{
+					Votes: 83,
+					Value: 8.7,
+				},
+				Statistics: &sonarr.Statistics{
+					SeasonCount:       1,
+					EpisodeFileCount:  0,
+					EpisodeCount:      5,
+					TotalEpisodeCount: 19,
+					SizeOnDisk:        0,
+					PercentOfEpisodes: 0.0,
+				},
+				ID: 2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:            "404",
+			ExpectedPath:    path.Join("/", starr.API, sonarr.APIver, "series/1?moveFiles=true"),
+			ExpectedMethod:  "PUT",
+			ExpectedRequest: updateSeries,
+			ResponseStatus:  404,
+			WithRequest: &sonarr.AddSeriesInput{
+				Title: "Chernobyl",
+				Seasons: []*sonarr.Season{
+					{
+						SeasonNumber: 0,
+						Monitored:    false,
+					},
+					{
+						SeasonNumber: 1,
+						Monitored:    true,
+					},
+				},
+				Path:              "/series/Chernobyl",
+				QualityProfileID:  1,
+				LanguageProfileID: 1,
+				SeasonFolder:      true,
+				Monitored:         true,
+				TvdbID:            360893,
+				RootFolderPath:    "/series/",
+				Tags: []int{
+					11,
+				},
+				ID: 1,
+			},
+			ResponseBody: starr.BodyNotFound,
+			WithError:    starr.ErrInvalidStatusCode,
+			WithResponse: (*sonarr.Series)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateSeries(test.WithRequest.(*sonarr.AddSeriesInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteSeries(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series/2?addImportListExclusion=false&deleteFiles=true"),
+			ExpectedMethod: "DELETE",
+			ResponseStatus: 200,
+			ResponseBody:   "{}",
+			WithRequest:    2,
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series/2?addImportListExclusion=false&deleteFiles=true"),
+			ExpectedMethod: "DELETE",
+			ResponseStatus: 404,
+			ResponseBody:   starr.BodyNotFound,
+			WithRequest:    2,
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteSeriesDefault(test.WithRequest.(int))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}
+
+func TestLookupName(t *testing.T) {
+	t.Parallel()
+
+	loc, _ := time.LoadLocation("")
+	date := time.Date(2019, 6, 4, 1, 0, 0, 0, loc)
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series/lookup?term=Chernobyl+Breaking+Bad"),
+			ExpectedMethod: "GET",
+			WithRequest:    "Chernobyl Breaking Bad",
+			ResponseStatus: 200,
+			ResponseBody:   listSeries,
+			WithResponse: []*sonarr.Series{
+				{
+					Title:           "Breaking Bad",
+					AlternateTitles: []*sonarr.AlternateTitle{},
+					SortTitle:       "breaking bad",
+					Status:          "ended",
+					Ended:           true,
+					Overview:        "Cool teacher becomes drug dealer",
+					PreviousAiring:  date,
+					Network:         "Netflix",
+					AirTime:         "21:00",
+					Images: []*starr.Image{
+						{
+							CoverType: "banner",
+							URL:       "/MediaCover/1/banner.jpg?lastWrite=637829401993017870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/graphical/81189-g21.jpg",
+						},
+						{
+							CoverType: "poster",
+							URL:       "/MediaCover/1/poster.jpg?lastWrite=637829401994817870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/posters/81189-10.jpg",
+						},
+						{
+							CoverType: "fanart",
+							URL:       "/MediaCover/1/fanart.jpg?lastWrite=637829401996517870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/fanart/original/81189-21.jpg",
+						},
+					},
+					Seasons: []*sonarr.Season{
+						{
+							SeasonNumber: 0,
+							Monitored:    false,
+							Statistics: &sonarr.Statistics{
+								EpisodeFileCount:  0,
+								EpisodeCount:      0,
+								TotalEpisodeCount: 19,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 1,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      7,
+								TotalEpisodeCount: 7,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 2,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      13,
+								TotalEpisodeCount: 13,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 3,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      13,
+								TotalEpisodeCount: 13,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 4,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      13,
+								TotalEpisodeCount: 13,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 5,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      16,
+								TotalEpisodeCount: 16,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+					},
+					Year:              2008,
+					Path:              "/series/Breaking Bad",
+					QualityProfileID:  1,
+					LanguageProfileID: 1,
+					SeasonFolder:      true,
+					Monitored:         true,
+					UseSceneNumbering: false,
+					Runtime:           47,
+					TvdbID:            81189,
+					TvRageID:          18164,
+					TvMazeID:          169,
+					FirstAired:        date,
+					SeriesType:        "standard",
+					CleanTitle:        "breakingbad",
+					ImdbID:            "tt0903747",
+					TitleSlug:         "breaking-bad",
+					RootFolderPath:    "/series/",
+					Certification:     "TV-MA",
+					Genres: []string{
+						"Crime",
+						"Drama",
+						"Suspense",
+						"Thriller",
+					},
+					Tags: []int{
+						11,
+					},
+					Added: date,
+					Ratings: &starr.Ratings{
+						Votes: 31714,
+						Value: 9.4,
+					},
+					Statistics: &sonarr.Statistics{
+						SeasonCount:       5,
+						EpisodeFileCount:  0,
+						EpisodeCount:      62,
+						TotalEpisodeCount: 81,
+						SizeOnDisk:        0,
+						PercentOfEpisodes: 0.0,
+					},
+					ID: 1,
+				},
+				{
+					Title:           "Chernobyl",
+					AlternateTitles: []*sonarr.AlternateTitle{},
+					SortTitle:       "chernobyl",
+					Status:          "ended",
+					Ended:           true,
+					Overview:        "A lot of energy wasted",
+					PreviousAiring:  date,
+					Network:         "HBO",
+					AirTime:         "21:00",
+					Images: []*starr.Image{
+						{
+							CoverType: "banner",
+							URL:       "/MediaCover/2/banner.jpg?lastWrite=637829402715717870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/graphical/5cc9f74c2ddd3.jpg",
+						},
+						{
+							CoverType: "poster",
+							URL:       "/MediaCover/2/poster.jpg?lastWrite=637829402718117870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/posters/5cc12861c93e4.jpg",
+						},
+						{
+							CoverType: "fanart",
+							URL:       "/MediaCover/2/fanart.jpg?lastWrite=637829402721317870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/series/360893/backgrounds/62017319.jpg",
+						},
+					},
+					Seasons: []*sonarr.Season{
+						{
+							SeasonNumber: 0,
+							Monitored:    false,
+							Statistics: &sonarr.Statistics{
+								EpisodeFileCount:  0,
+								EpisodeCount:      0,
+								TotalEpisodeCount: 14,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 1,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      5,
+								TotalEpisodeCount: 5,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+					},
+					Year:              2019,
+					Path:              "/series/Chernobyl",
+					QualityProfileID:  1,
+					LanguageProfileID: 1,
+					SeasonFolder:      true,
+					Monitored:         true,
+					UseSceneNumbering: false,
+					Runtime:           65,
+					TvdbID:            360893,
+					TvRageID:          0,
+					TvMazeID:          30770,
+					FirstAired:        date,
+					SeriesType:        "standard",
+					CleanTitle:        "chernobyl",
+					ImdbID:            "tt7366338",
+					TitleSlug:         "chernobyl",
+					RootFolderPath:    "/series/",
+					Certification:     "TV-MA",
+					Genres: []string{
+						"Drama",
+						"History",
+						"Mini-Series",
+						"Thriller",
+					},
+					Tags: []int{
+						11,
+					},
+					Added: date,
+					Ratings: &starr.Ratings{
+						Votes: 83,
+						Value: 8.7,
+					},
+					Statistics: &sonarr.Statistics{
+						SeasonCount:       1,
+						EpisodeFileCount:  0,
+						EpisodeCount:      5,
+						TotalEpisodeCount: 19,
+						SizeOnDisk:        0,
+						PercentOfEpisodes: 0.0,
+					},
+					ID: 2,
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series/lookup?term=Chernobyl+Breaking+Bad"),
+			ExpectedMethod: "GET",
+			WithRequest:    "Chernobyl Breaking Bad",
+			ResponseStatus: 404,
+			ResponseBody:   starr.BodyNotFound,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   []*sonarr.Series(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.Lookup(test.WithRequest.(string))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}
+
+func TestLookupID(t *testing.T) {
+	t.Parallel()
+
+	loc, _ := time.LoadLocation("")
+	date := time.Date(2019, 6, 4, 1, 0, 0, 0, loc)
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series/lookup?term=tvdbid%3A360893"),
+			ExpectedMethod: "GET",
+			WithRequest:    360893,
+			ResponseStatus: 200,
+			ResponseBody:   "[" + secondSeries + "]",
+			WithResponse: []*sonarr.Series{
+				{
+					Title:           "Chernobyl",
+					AlternateTitles: []*sonarr.AlternateTitle{},
+					SortTitle:       "chernobyl",
+					Status:          "ended",
+					Ended:           true,
+					Overview:        "A lot of energy wasted",
+					PreviousAiring:  date,
+					Network:         "HBO",
+					AirTime:         "21:00",
+					Images: []*starr.Image{
+						{
+							CoverType: "banner",
+							URL:       "/MediaCover/2/banner.jpg?lastWrite=637829402715717870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/graphical/5cc9f74c2ddd3.jpg",
+						},
+						{
+							CoverType: "poster",
+							URL:       "/MediaCover/2/poster.jpg?lastWrite=637829402718117870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/posters/5cc12861c93e4.jpg",
+						},
+						{
+							CoverType: "fanart",
+							URL:       "/MediaCover/2/fanart.jpg?lastWrite=637829402721317870",
+							RemoteURL: "https://artworks.thetvdb.com/banners/series/360893/backgrounds/62017319.jpg",
+						},
+					},
+					Seasons: []*sonarr.Season{
+						{
+							SeasonNumber: 0,
+							Monitored:    false,
+							Statistics: &sonarr.Statistics{
+								EpisodeFileCount:  0,
+								EpisodeCount:      0,
+								TotalEpisodeCount: 14,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+						{
+							SeasonNumber: 1,
+							Monitored:    true,
+							Statistics: &sonarr.Statistics{
+								PreviousAiring:    date,
+								EpisodeFileCount:  0,
+								EpisodeCount:      5,
+								TotalEpisodeCount: 5,
+								SizeOnDisk:        0,
+								PercentOfEpisodes: 0.0,
+							},
+						},
+					},
+					Year:              2019,
+					Path:              "/series/Chernobyl",
+					QualityProfileID:  1,
+					LanguageProfileID: 1,
+					SeasonFolder:      true,
+					Monitored:         true,
+					UseSceneNumbering: false,
+					Runtime:           65,
+					TvdbID:            360893,
+					TvRageID:          0,
+					TvMazeID:          30770,
+					FirstAired:        date,
+					SeriesType:        "standard",
+					CleanTitle:        "chernobyl",
+					ImdbID:            "tt7366338",
+					TitleSlug:         "chernobyl",
+					RootFolderPath:    "/series/",
+					Certification:     "TV-MA",
+					Genres: []string{
+						"Drama",
+						"History",
+						"Mini-Series",
+						"Thriller",
+					},
+					Tags: []int{
+						11,
+					},
+					Added: date,
+					Ratings: &starr.Ratings{
+						Votes: 83,
+						Value: 8.7,
+					},
+					Statistics: &sonarr.Statistics{
+						SeasonCount:       1,
+						EpisodeFileCount:  0,
+						EpisodeCount:      5,
+						TotalEpisodeCount: 19,
+						SizeOnDisk:        0,
+						PercentOfEpisodes: 0.0,
+					},
+					ID: 2,
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "series/lookup?term=tvdbid%3A360893"),
+			ExpectedMethod: "GET",
+			WithRequest:    360893,
+			ResponseStatus: 404,
+			ResponseBody:   starr.BodyNotFound,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   []*sonarr.Series(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetSeriesLookup("", int64(test.WithRequest.(int)))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}

--- a/sonarr/type.go
+++ b/sonarr/type.go
@@ -82,64 +82,6 @@ type QueueRecord struct {
 	ErrorMessage            string                 `json:"errorMessage"`
 }
 
-// Series the /api/v3/series endpoint.
-type Series struct {
-	ID                int64             `json:"id"`
-	Title             string            `json:"title,omitempty"`
-	AlternateTitles   []*AlternateTitle `json:"alternateTitles,omitempty"`
-	SortTitle         string            `json:"sortTitle,omitempty"`
-	Status            string            `json:"status,omitempty"`
-	Overview          string            `json:"overview,omitempty"`
-	PreviousAiring    time.Time         `json:"previousAiring,omitempty"`
-	Network           string            `json:"network,omitempty"`
-	Images            []*starr.Image    `json:"images,omitempty"`
-	Seasons           []*Season         `json:"seasons,omitempty"`
-	Year              int               `json:"year,omitempty"`
-	Path              string            `json:"path,omitempty"`
-	QualityProfileID  int64             `json:"qualityProfileId,omitempty"`
-	LanguageProfileID int64             `json:"languageProfileId,omitempty"`
-	Runtime           int               `json:"runtime,omitempty"`
-	TvdbID            int64             `json:"tvdbId,omitempty"`
-	TvRageID          int64             `json:"tvRageId,omitempty"`
-	TvMazeID          int64             `json:"tvMazeId,omitempty"`
-	FirstAired        time.Time         `json:"firstAired,omitempty"`
-	SeriesType        string            `json:"seriesType,omitempty"`
-	CleanTitle        string            `json:"cleanTitle,omitempty"`
-	ImdbID            string            `json:"imdbId,omitempty"`
-	TitleSlug         string            `json:"titleSlug,omitempty"`
-	RootFolderPath    string            `json:"rootFolderPath,omitempty"`
-	Certification     string            `json:"certification,omitempty"`
-	Genres            []string          `json:"genres,omitempty"`
-	Tags              []int             `json:"tags,omitempty"`
-	Added             time.Time         `json:"added,omitempty"`
-	Ratings           *starr.Ratings    `json:"ratings,omitempty"`
-	Statistics        *Statistics       `json:"statistics,omitempty"`
-	NextAiring        time.Time         `json:"nextAiring,omitempty"`
-	AirTime           string            `json:"airTime,omitempty"`
-	Ended             bool              `json:"ended,omitempty"`
-	SeasonFolder      bool              `json:"seasonFolder,omitempty"`
-	Monitored         bool              `json:"monitored"`
-	UseSceneNumbering bool              `json:"useSceneNumbering,omitempty"`
-}
-
-// Statistics is part of Queue.
-type Statistics struct {
-	SeasonCount       int       `json:"seasonCount"`
-	PreviousAiring    time.Time `json:"previousAiring"`
-	EpisodeFileCount  int       `json:"episodeFileCount"`
-	EpisodeCount      int       `json:"episodeCount"`
-	TotalEpisodeCount int       `json:"totalEpisodeCount"`
-	SizeOnDisk        int64     `json:"sizeOnDisk"`
-	PercentOfEpisodes float64   `json:"percentOfEpisodes"`
-}
-
-// Season is part of Queue and used in a few places.
-type Season struct {
-	SeasonNumber int         `json:"seasonNumber"`
-	Monitored    bool        `json:"monitored"`
-	Statistics   *Statistics `json:"statistics,omitempty"`
-}
-
 // Episode is the /api/v3/episode endpoint.
 type Episode struct {
 	ID                       int64     `json:"id"`
@@ -155,73 +97,6 @@ type Episode struct {
 	UnverifiedSceneNumbering bool      `json:"unverifiedSceneNumbering"`
 	HasFile                  bool      `json:"hasFile"`
 	Monitored                bool      `json:"monitored"`
-}
-
-// AddSeriesInput is the input for a POST to the /api/v3/series endpoint.
-type AddSeriesInput struct {
-	ID                int64             `json:"id,omitempty"`
-	TvdbID            int64             `json:"tvdbId"`
-	QualityProfileID  int64             `json:"qualityProfileId"`
-	LanguageProfileID int64             `json:"languageProfileId"`
-	Tags              []int             `json:"tags"`
-	RootFolderPath    string            `json:"rootFolderPath"`
-	Title             string            `json:"title,omitempty"`
-	SeriesType        string            `json:"seriesType,omitempty"`
-	Seasons           []*Season         `json:"seasons"`
-	AddOptions        *AddSeriesOptions `json:"addOptions"`
-	SeasonFolder      bool              `json:"seasonFolder"`
-	Monitored         bool              `json:"monitored"`
-}
-
-// AddSeriesOptions is part of AddSeriesInput.
-type AddSeriesOptions struct {
-	SearchForMissingEpisodes     bool `json:"searchForMissingEpisodes"`
-	SearchForCutoffUnmetEpisodes bool `json:"searchForCutoffUnmetEpisodes,omitempty"`
-	IgnoreEpisodesWithFiles      bool `json:"ignoreEpisodesWithFiles,omitempty"`
-	IgnoreEpisodesWithoutFiles   bool `json:"ignoreEpisodesWithoutFiles,omitempty"`
-}
-
-// AddSeriesOutput is currently an unknown format.
-type AddSeriesOutput struct {
-	ID                int64             `json:"id"`
-	Title             string            `json:"title"`
-	AlternateTitles   []*AlternateTitle `json:"alternateTitles"`
-	SortTitle         string            `json:"sortTitle"`
-	Status            string            `json:"status"`
-	Overview          string            `json:"overview"`
-	Network           string            `json:"network"`
-	Images            []*starr.Image    `json:"images"`
-	Seasons           []*Season         `json:"seasons"`
-	Year              int               `json:"year"`
-	Path              string            `json:"path"`
-	QualityProfileID  int64             `json:"qualityProfileId"`
-	LanguageProfileID int64             `json:"languageProfileId"`
-	Runtime           int               `json:"runtime"`
-	TvdbID            int64             `json:"tvdbId"`
-	TvRageID          int64             `json:"tvRageId"`
-	TvMazeID          int64             `json:"tvMazeId"`
-	FirstAired        time.Time         `json:"firstAired"`
-	SeriesType        string            `json:"seriesType"`
-	CleanTitle        string            `json:"cleanTitle"`
-	ImdbID            string            `json:"imdbId"`
-	TitleSlug         string            `json:"titleSlug"`
-	RootFolderPath    string            `json:"rootFolderPath"`
-	Genres            []string          `json:"genres"`
-	Tags              []int             `json:"tags"`
-	Added             time.Time         `json:"added"`
-	AddOptions        *AddSeriesOptions `json:"addOptions"`
-	Ratings           *starr.Ratings    `json:"ratings"`
-	Statistics        *Statistics       `json:"statistics"`
-	Ended             bool              `json:"ended"`
-	SeasonFolder      bool              `json:"seasonFolder"`
-	Monitored         bool              `json:"monitored"`
-	UseSceneNumbering bool              `json:"useSceneNumbering"`
-}
-
-// AlternateTitle is part of a Series.
-type AlternateTitle struct {
-	Title        string `json:"title"`
-	SeasonNumber int    `json:"seasonNumber"`
 }
 
 // History is the data from the /api/v3/history endpoint.

--- a/test_methods.go
+++ b/test_methods.go
@@ -23,20 +23,30 @@ type TestMockData struct {
 	WithError       error       // Caller's response.
 }
 
+const (
+	// Error body for 401 response.
+	BodyUnauthorized = `{"error": "Unauthorized"}`
+	// Error body for 404 response.
+	BodyNotFound = `{"message": "NotFound"}`
+	// Error body for 405 response.
+	BodyMethodNotAllowed = `{"message": "MethodNotAllowed"}`
+)
+
 // GetMockServer is used in all the http tests.
 func (test *TestMockData) GetMockServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
 		assert.EqualValues(t, test.ExpectedPath, req.URL.String())
-		w.WriteHeader(test.ResponseStatus)
+		writer.WriteHeader(test.ResponseStatus)
 
-		_, err := w.Write([]byte(test.ResponseBody))
-		assert.NoError(t, err)
 		assert.EqualValues(t, req.Method, test.ExpectedMethod)
 
 		body, err := ioutil.ReadAll(req.Body)
 		assert.NoError(t, err)
 		assert.EqualValues(t, test.ExpectedRequest, string(body))
+
+		_, err = writer.Write([]byte(test.ResponseBody))
+		assert.NoError(t, err)
 	}))
 }


### PR DESCRIPTION
Hi @davidnewhall,
These the proposed changes to series:

- using a single struct for series even if some responses and some inputs can have different empty values (mainly changes AddSeries)
- in UpdateSeries remove the ID input and leverage the ID inside the struct
- add DeleteSeries. I enforced as general behaviour to remove files and not exclude from importlist. If you prefer, we can pass the two flags as inputs.
- moving time.Time type to reference in struct. I know it's not best practice to use reference instead of values for time. However, *time.Time with "omitempty" tag is really omitted in json, while time.Time is still enforced with a 0 value. This allow us to omit time.Time fields in requests.
- add series tests
- I had to move the request checks before the response checks in GetMockServer. It seems that once the request is closed and the response is ready, the request cannot be read anymore. Still, I don't understand why it didn't trigger the error for the other tests we did.

p.s.
Sorry for the multiple builds. If you prefer, I can go back in using the forked repository.