### PR TITLE
build: fix golangci-lint endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ language: go
 go:
   - 1.17.x
 install:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
 script:
   - make test


### PR DESCRIPTION
since install.goreleaser.com isn't resolved anymore, this is to update the endpoint as per https://golangci-lint.run/usage/install/