### PR TITLE
feat(sonarr): add indexer methods

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -118,6 +118,29 @@ type Value struct {
 	Name string `json:"name"`
 }
 
+// Fields is generic Name/Value struct applied to a few places.
+type Field struct {
+	Advanced                    bool            `json:"advanced,omitempty"`
+	Order                       int64           `json:"order,omitempty"`
+	HelpLink                    string          `json:"helpLink,omitempty"`
+	HelpText                    string          `json:"helpText,omitempty"`
+	Hidden                      string          `json:"hidden,omitempty"`
+	Label                       string          `json:"label,omitempty"`
+	Name                        string          `json:"name"`
+	SelectOptionsProviderAction string          `json:"selectOptionsProviderAction,omitempty"`
+	Type                        string          `json:"type,omitempty"`
+	Value                       interface{}     `json:"value,omitempty"`
+	SelectOptions               []*SelectOption `json:"selectOptions,omitempty"`
+}
+
+// SelectOption is part of Field
+type SelectOption struct {
+	Order int64  `json:"order"`
+	Value int64  `json:"value"`
+	Hint  string `json:"hint"`
+	Name  string `json:"name"`
+}
+
 // KeyValue is yet another reusable generic type.
 type KeyValue struct {
 	Key   string `json:"key"`

--- a/shared.go
+++ b/shared.go
@@ -2,7 +2,6 @@ package starr
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -119,8 +118,8 @@ type Value struct {
 	Name string `json:"name"`
 }
 
-// Field is generic Name/Value struct applied to a few places.
-type Field struct {
+// FieldOutput is generic Name/Value struct applied to a few places.
+type FieldOutput struct {
 	Advanced                    bool            `json:"advanced,omitempty"`
 	Order                       int64           `json:"order,omitempty"`
 	HelpLink                    string          `json:"helpLink,omitempty"`
@@ -134,18 +133,10 @@ type Field struct {
 	SelectOptions               []*SelectOption `json:"selectOptions,omitempty"`
 }
 
-func (f *Field) GetFieldValueString() (string, error) {
-	if v, a := f.Value.(string); !a {
-		return v, nil
-	}
-	return "", fmt.Errorf("Field %s has invalid value", f.Name)
-}
-
-func (f *Field) GetFieldValueBool() (bool, error) {
-	if v, a := f.Value.(bool); !a {
-		return v, nil
-	}
-	return false, fmt.Errorf("Field %s has invalid value", f.Name)
+// FieldInput is generic Name/Value struct applied to a few places.
+type FieldInput struct {
+	Name  string      `json:"name"`
+	Value interface{} `json:"value,omitempty"`
 }
 
 // SelectOption is part of Field

--- a/shared.go
+++ b/shared.go
@@ -139,7 +139,7 @@ type FieldInput struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
-// SelectOption is part of Field
+// SelectOption is part of Field.
 type SelectOption struct {
 	Order int64  `json:"order"`
 	Value int64  `json:"value"`

--- a/shared.go
+++ b/shared.go
@@ -2,6 +2,7 @@ package starr
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -118,7 +119,7 @@ type Value struct {
 	Name string `json:"name"`
 }
 
-// Fields is generic Name/Value struct applied to a few places.
+// Field is generic Name/Value struct applied to a few places.
 type Field struct {
 	Advanced                    bool            `json:"advanced,omitempty"`
 	Order                       int64           `json:"order,omitempty"`
@@ -131,6 +132,20 @@ type Field struct {
 	Type                        string          `json:"type,omitempty"`
 	Value                       interface{}     `json:"value,omitempty"`
 	SelectOptions               []*SelectOption `json:"selectOptions,omitempty"`
+}
+
+func (f *Field) GetFieldValueString() (string, error) {
+	if v, a := f.Value.(string); !a {
+		return v, nil
+	}
+	return "", fmt.Errorf("Field %s has invalid value", f.Name)
+}
+
+func (f *Field) GetFieldValueBool() (bool, error) {
+	if v, a := f.Value.(bool); !a {
+		return v, nil
+	}
+	return false, fmt.Errorf("Field %s has invalid value", f.Name)
 }
 
 // SelectOption is part of Field

--- a/sonarr/indexer.go
+++ b/sonarr/indexer.go
@@ -15,7 +15,7 @@ type IndexerInput struct {
 	EnableAutomaticSearch   bool                `json:"enableAutomaticSearch"`
 	EnableInteractiveSearch bool                `json:"enableInteractiveSearch"`
 	EnableRss               bool                `json:"enableRss"`
-	DownloadClientId        int64               `json:"downloadClientId"`
+	DownloadClientID        int64               `json:"downloadClientId"`
 	Priority                int64               `json:"priority"`
 	ID                      int64               `json:"id,omitempty"`
 	ConfigContract          string              `json:"configContract"`
@@ -32,7 +32,7 @@ type IndexerOutput struct {
 	EnableRss               bool                 `json:"enableRss"`
 	SupportsRss             bool                 `json:"supportsRss"`
 	SupportsSearch          bool                 `json:"supportsSearch"`
-	DownloadClientId        int64                `json:"downloadClientId"`
+	DownloadClientID        int64                `json:"DownloadClientID"`
 	Priority                int64                `json:"priority"`
 	ID                      int64                `json:"id,omitempty"`
 	ConfigContract          string               `json:"configContract"`
@@ -46,6 +46,21 @@ type IndexerOutput struct {
 }
 
 const bpIndexer = APIver + "/indexer"
+
+// GetIndexers returns all configured indexerss.
+func (s *Sonarr) GetIndexers() ([]*IndexerOutput, error) {
+	return s.GetIndexersContext(context.Background())
+}
+
+func (s *Sonarr) GetIndexersContext(ctx context.Context) ([]*IndexerOutput, error) {
+	var output []*IndexerOutput
+
+	if _, err := s.GetInto(ctx, bpIndexer, nil, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(qualityProfile): %w", err)
+	}
+
+	return output, nil
+}
 
 // GetIndexer returns a single indexer.
 func (s *Sonarr) GetIndexer(indexerID int) (*IndexerOutput, error) {

--- a/sonarr/indexer.go
+++ b/sonarr/indexer.go
@@ -12,84 +12,40 @@ import (
 )
 
 type IndexerInput struct {
-	EnableAutomaticSearch   bool           `json:"enableAutomaticSearch"`
-	EnableInteractiveSearch bool           `json:"enableInteractiveSearch"`
-	EnableRss               bool           `json:"enableRss"`
-	Priority                int64          `json:"priority"`
-	ID                      int64          `json:"id,omitempty"`
-	ConfigContract          string         `json:"configContract"`
-	Implementation          string         `json:"implementation"`
-	Name                    string         `json:"name"`
-	Protocol                string         `json:"protocol"`
-	Fields                  IndexerFields  `json:"fields"`
-	Tags                    []*starr.Value `json:"tags"`
+	EnableAutomaticSearch   bool                `json:"enableAutomaticSearch"`
+	EnableInteractiveSearch bool                `json:"enableInteractiveSearch"`
+	EnableRss               bool                `json:"enableRss"`
+	DownloadClientId        int64               `json:"downloadClientId"`
+	Priority                int64               `json:"priority"`
+	ID                      int64               `json:"id,omitempty"`
+	ConfigContract          string              `json:"configContract"`
+	Implementation          string              `json:"implementation"`
+	Name                    string              `json:"name"`
+	Protocol                string              `json:"protocol"`
+	Tags                    []int               `json:"tags"`
+	Fields                  []*starr.FieldInput `json:"fields"`
 }
 
 type IndexerOutput struct {
-	EnableAutomaticSearch   bool           `json:"enableAutomaticSearch"`
-	EnableInteractiveSearch bool           `json:"enableInteractiveSearch"`
-	EnableRss               bool           `json:"enableRss"`
-	SupportsRss             bool           `json:"supportsRss"`
-	SupportsSearch          bool           `json:"supportsSearch"`
-	Priority                int64          `json:"priority"`
-	ID                      int64          `json:"id,omitempty"`
-	ConfigContract          string         `json:"configContract"`
-	Implementation          string         `json:"implementation"`
-	ImplementationName      string         `json:"implementationName"`
-	InfoLink                string         `json:"infoLink"`
-	Name                    string         `json:"name"`
-	Protocol                string         `json:"protocol"`
-	Fields                  IndexerFields  `json:"fields"`
-	Tags                    []*starr.Value `json:"tags"`
-}
-
-type IndexerFields struct {
-	AllowZeroSize *bool `json:"allowZeroSize,omitempty"`
-	// RankedOnly           bool    `json:"rankedOnly,omitempty"`
-	// Delay                int64   `json:"delay,omitempty"`
-	// MinimumSeeders       int64   `json:"minimumSeeders,omitempty"`
-	// SeasonPackSeedTime   int64   `json:"seasonPackSeedTime,omitempty"`
-	// SeedTime             int64   `json:"seedTime,omitempty"`
-	// SeedRatio            float64 `json:"seedRatio,omitempty"`
-	// AdditionalParameters string  `json:"additionalParameters,omitempty"`
-	ApiKey  *string `json:"apiKey,omitempty"`
-	ApiPath *string `json:"apiPath,omitempty"`
-	// BaseUrl              string  `json:"baseUrl,omitempty"`
-	// CaptchaToken         string  `json:"captchaToken,omitempty"`
-	// Cookie               string  `json:"cookie,omitempty"`
-	// Passkey              string  `json:"passkey,omitempty"`
-	// Username             string  `json:"username,omitempty"`
-	// AnimeCategories      []int64 `json:"animeCategories,omitempty"`
-	// Categories           []int64 `json:"Categories,omitempty"`
-}
-
-type indexerAPI struct {
-	EnableAutomaticSearch   bool           `json:"enableAutomaticSearch"`
-	EnableInteractiveSearch bool           `json:"enableInteractiveSearch"`
-	EnableRss               bool           `json:"enableRss"`
-	SupportsRss             bool           `json:"supportsRss,omitempty"`
-	SupportsSearch          bool           `json:"supportsSearch,omitempty"`
-	Priority                int64          `json:"priority"`
-	ID                      int64          `json:"id,omitempty"`
-	ConfigContract          string         `json:"configContract"`
-	Implementation          string         `json:"implementation"`
-	ImplementationName      string         `json:"implementationName,omitempty"`
-	InfoLink                string         `json:"infoLink,omitempty"`
-	Name                    string         `json:"name"`
-	Protocol                string         `json:"protocol"`
-	Tags                    []*starr.Value `json:"tags"`
-	Fields                  []*starr.Field `json:"fields"`
+	EnableAutomaticSearch   bool                 `json:"enableAutomaticSearch"`
+	EnableInteractiveSearch bool                 `json:"enableInteractiveSearch"`
+	EnableRss               bool                 `json:"enableRss"`
+	SupportsRss             bool                 `json:"supportsRss"`
+	SupportsSearch          bool                 `json:"supportsSearch"`
+	DownloadClientId        int64                `json:"downloadClientId"`
+	Priority                int64                `json:"priority"`
+	ID                      int64                `json:"id,omitempty"`
+	ConfigContract          string               `json:"configContract"`
+	Implementation          string               `json:"implementation"`
+	ImplementationName      string               `json:"implementationName"`
+	InfoLink                string               `json:"infoLink"`
+	Name                    string               `json:"name"`
+	Protocol                string               `json:"protocol"`
+	Tags                    []int                `json:"tags"`
+	Fields                  []*starr.FieldOutput `json:"fields"`
 }
 
 const bpIndexer = APIver + "/indexer"
-
-// var (
-// 	IndexerFieldsString   = []string{"additionalParameters", "apiKey", "apiPath", "baseUrl", "captchaToken", "cookie", "passkey", "username"}
-// 	IndexerFieldsBool     = []string{"allowZeroSize", "rankedOnly"}
-// 	IndexerFieldsInt      = []string{"delay", "minimumSeeders", "seedCriteria.seasonPackSeedTime", "seedCriteria.seedTime"}
-// 	IndexerFieldsFloat    = []string{"seedCriteria.seedRatio"}
-// 	IndexerFieldsIntSlice = []string{"animeCategories", "categories"}
-// )
 
 // GetIndexer returns a single indexer.
 func (s *Sonarr) GetIndexer(indexerID int) (*IndexerOutput, error) {
@@ -97,16 +53,11 @@ func (s *Sonarr) GetIndexer(indexerID int) (*IndexerOutput, error) {
 }
 
 func (s *Sonarr) GetIndexerContext(ctx context.Context, indexerID int) (*IndexerOutput, error) {
-	var response *indexerAPI
+	var output *IndexerOutput
 
 	uri := path.Join(bpIndexer, strconv.Itoa(indexerID))
-	if _, err := s.GetInto(ctx, uri, nil, &response); err != nil {
+	if _, err := s.GetInto(ctx, uri, nil, &output); err != nil {
 		return nil, fmt.Errorf("api.Get(indexer): %w", err)
-	}
-
-	output, err := getIndexerOutput(response)
-	if err != nil {
-		return nil, err
 	}
 
 	return output, nil
@@ -118,117 +69,51 @@ func (s *Sonarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
 }
 
 func (s *Sonarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
-	request, err := setIndexerInput(indexer)
-	if err != nil {
-		return nil, err
-	}
+	var output *IndexerOutput
 
 	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(request); err != nil {
+	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
 		return nil, fmt.Errorf("json.Marshal(indexer): %w", err)
 	}
 
-	var response *indexerAPI
-	if _, err := s.PostInto(ctx, bpIndexer, nil, &body, &response); err != nil {
+	if _, err := s.PostInto(ctx, bpIndexer, nil, &body, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(indexer): %w", err)
 	}
 
-	output, err := getIndexerOutput(response)
-	if err != nil {
-		return nil, err
-	}
-
 	return output, nil
 }
 
-func getIndexerOutput(indexer *indexerAPI) (*IndexerOutput, error) {
-	fields, err := getIndexerFields(indexer.Fields)
-	if err != nil {
-		return nil, err
-	}
-	return &IndexerOutput{
-		EnableAutomaticSearch:   indexer.EnableAutomaticSearch,
-		EnableInteractiveSearch: indexer.EnableInteractiveSearch,
-		EnableRss:               indexer.EnableRss,
-		SupportsRss:             indexer.SupportsRss,
-		SupportsSearch:          indexer.SupportsSearch,
-		Priority:                indexer.Priority,
-		ID:                      indexer.ID,
-		ConfigContract:          indexer.ConfigContract,
-		Implementation:          indexer.Implementation,
-		ImplementationName:      indexer.ImplementationName,
-		InfoLink:                indexer.InfoLink,
-		Name:                    indexer.Name,
-		Protocol:                indexer.Protocol,
-		Fields:                  *fields,
-		Tags:                    indexer.Tags,
-	}, nil
+// UpdateIndexer updates the indexer.
+func (s *Sonarr) UpdateIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
+	return s.UpdateIndexerContext(context.Background(), indexer)
 }
 
-func getIndexerFields(fields []*starr.Field) (*IndexerFields, error) {
-	var output *IndexerFields
-	var err error
-	for _, f := range fields {
-		switch f.Name {
-		case "apiKey":
-			*output.ApiKey, err = f.GetFieldValueString()
-			if err != nil {
-				return nil, err
-			}
-		case "apiPath":
-			*output.ApiPath, err = f.GetFieldValueString()
-			if err != nil {
-				return nil, err
-			}
-		case "allowZeroSize":
-			*output.AllowZeroSize, err = f.GetFieldValueBool()
-			if err != nil {
-				return nil, err
-			}
-		default:
-			return nil, fmt.Errorf("Field %s is not a known indexer field", f.Name)
-		}
+func (s *Sonarr) UpdateIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
+	var output IndexerOutput
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
+		return nil, fmt.Errorf("json.Marshal(Indexer): %w", err)
 	}
 
-	return output, nil
+	uri := path.Join(bpIndexer, strconv.Itoa(int(indexer.ID)))
+	if _, err := s.PutInto(ctx, uri, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(Indexer): %w", err)
+	}
+
+	return &output, nil
 }
 
-func setIndexerInput(indexer *IndexerInput) (*indexerAPI, error) {
-	fields := setIndexerFields(&indexer.Fields)
-	return &indexerAPI{
-		EnableAutomaticSearch:   indexer.EnableAutomaticSearch,
-		EnableInteractiveSearch: indexer.EnableInteractiveSearch,
-		EnableRss:               indexer.EnableRss,
-		Priority:                indexer.Priority,
-		ID:                      indexer.ID,
-		ConfigContract:          indexer.ConfigContract,
-		Implementation:          indexer.Implementation,
-		Name:                    indexer.Name,
-		Protocol:                indexer.Protocol,
-		Fields:                  fields,
-		Tags:                    indexer.Tags,
-	}, nil
+// DeleteIndexer removes a single indexer.
+func (s *Sonarr) DeleteIndexer(indexerID int) error {
+	return s.DeleteIndexerContext(context.Background(), indexerID)
 }
 
-func setIndexerFields(fields *IndexerFields) []*starr.Field {
-	var output []*starr.Field
-	if fields.ApiKey != nil {
-		output = append(output, &starr.Field{
-			Name:  "apiKey",
-			Value: *fields.ApiKey,
-		})
+func (s *Sonarr) DeleteIndexerContext(ctx context.Context, indexerID int) error {
+	uri := path.Join(bpIndexer, strconv.Itoa(indexerID))
+	if _, err := s.Delete(ctx, uri, nil); err != nil {
+		return fmt.Errorf("api.Delete(Indexer): %w", err)
 	}
-	if fields.ApiPath != nil {
-		output = append(output, &starr.Field{
-			Name:  "apiPath",
-			Value: *fields.ApiPath,
-		})
-	}
-	if fields.AllowZeroSize != nil {
-		output = append(output, &starr.Field{
-			Name:  "allowZeroSize",
-			Value: *fields.AllowZeroSize,
-		})
-	}
-	return output
+
+	return nil
 }

--- a/sonarr/indexer.go
+++ b/sonarr/indexer.go
@@ -1,0 +1,196 @@
+package sonarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strconv"
+
+	"golift.io/starr"
+)
+
+type Indexer struct {
+	EnableAutomaticSearch   bool           `json:"enableAutomaticSearch"`
+	EnableInteractiveSearch bool           `json:"enableInteractiveSearch"`
+	EnableRss               bool           `json:"enableRss"`
+	SupportsRss             bool           `json:"supportsRss"`
+	SupportsSearch          bool           `json:"supportsSearch"`
+	Priority                int64          `json:"priority"`
+	ID                      int64          `json:"id,omitempty"`
+	ConfigContract          string         `json:"configContract"`
+	Implementation          string         `json:"implementation"`
+	ImplementationName      string         `json:"implementationName"`
+	InfoLink                string         `json:"infoLink"`
+	Name                    string         `json:"name"`
+	Protocol                string         `json:"protocol"`
+	Tags                    []*starr.Value `json:"tags"`
+	Fields                  []*starr.Field `json:"fields"`
+}
+
+const bpIndexer = APIver + "/indexer"
+
+var (
+	IndexerFieldsString   = []string{"additionalParameters", "apiKey", "apiPath", "baseUrl", "captchaToken", "cookie", "passkey", "username"}
+	IndexerFieldsBool     = []string{"allowZeroSize", "rankedOnly"}
+	IndexerFieldsInt      = []string{"delay", "minimumSeeders", "seedCriteria.seasonPackSeedTime", "seedCriteria.seedTime"}
+	IndexerFieldsFloat    = []string{"seedCriteria.seedRatio"}
+	IndexerFieldsIntSlice = []string{"animeCategories", "categories"}
+)
+
+// GetIndexers returns all configured indexers.
+func (s *Sonarr) GetIndexers() ([]*Indexer, error) {
+	return s.GetIndexersContext(context.Background())
+}
+
+func (s *Sonarr) GetIndexersContext(ctx context.Context) ([]*Indexer, error) {
+	var output []*Indexer
+
+	if _, err := s.GetInto(ctx, bpIndexer, nil, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(indexer): %w", err)
+	}
+
+	for i := range output {
+		output[i].Fields, _ = correctIndexerFieldsValue(output[i].Fields)
+	}
+	return output, nil
+}
+
+// GetIndexer returns a single indexer.
+func (s *Sonarr) GetIndexer(indexerID int) (*Indexer, error) {
+	return s.GetIndexerContext(context.Background(), indexerID)
+}
+
+func (s *Sonarr) GetIndexerContext(ctx context.Context, indexerID int) (*Indexer, error) {
+	var output *Indexer
+
+	uri := path.Join(bpIndexer, strconv.Itoa(indexerID))
+	if _, err := s.GetInto(ctx, uri, nil, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(indexer): %w", err)
+	}
+
+	output.Fields, _ = correctIndexerFieldsValue(output.Fields)
+	return output, nil
+}
+
+// AddIndexer creates a indexer.
+func (s *Sonarr) AddIndexer(indexer *Indexer) (*Indexer, error) {
+	return s.AddIndexerContext(context.Background(), indexer)
+}
+
+func (s *Sonarr) AddIndexerContext(ctx context.Context, indexer *Indexer) (*Indexer, error) {
+	var output Indexer
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
+		return nil, fmt.Errorf("json.Marshal(indexer): %w", err)
+	}
+
+	if _, err := s.PostInto(ctx, bpIndexer, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(indexer): %w", err)
+	}
+
+	output.Fields, _ = correctIndexerFieldsValue(output.Fields)
+	return &output, nil
+}
+
+// UpdateIndexer updates the indexer.
+func (s *Sonarr) UpdateIndexer(indexer *Indexer) (*Indexer, error) {
+	return s.UpdateIndexerContext(context.Background(), indexer)
+}
+
+func (s *Sonarr) UpdateIndexerContext(ctx context.Context, indexer *Indexer) (*Indexer, error) {
+	var output Indexer
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
+		return nil, fmt.Errorf("json.Marshal(indexer): %w", err)
+	}
+
+	uri := path.Join(bpIndexer, strconv.Itoa(int(indexer.ID)))
+	if _, err := s.PutInto(ctx, uri, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(indexer): %w", err)
+	}
+
+	output.Fields, _ = correctIndexerFieldsValue(output.Fields)
+	return &output, nil
+}
+
+// DeleteIndexer removes a single indexer.
+func (s *Sonarr) DeleteIndexer(indexerID int) error {
+	return s.DeleteIndexerContext(context.Background(), indexerID)
+}
+
+func (s *Sonarr) DeleteIndexerContext(ctx context.Context, indexerID int) error {
+	uri := path.Join(bpIndexer, strconv.Itoa(indexerID))
+	if _, err := s.Delete(ctx, uri, nil); err != nil {
+		return fmt.Errorf("api.Delete(indexer): %w", err)
+	}
+
+	return nil
+}
+
+// TestIndexer test the Indexer connectivity.
+func (s *Sonarr) TestIndexer(indexer *Indexer) (*Indexer, error) {
+	return s.AddIndexerContext(context.Background(), indexer)
+}
+
+func (s *Sonarr) TestIndexerContext(ctx context.Context, indexer *Indexer) (*Indexer, error) {
+	var output Indexer
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
+		return nil, fmt.Errorf("json.Marshal(indexer): %w", err)
+	}
+
+	uri := path.Join(bpIndexer, "test")
+	if _, err := s.PostInto(ctx, uri, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(indexerTest): %w", err)
+	}
+
+	return &output, nil
+}
+
+func correctIndexerFieldsValue(fields []*starr.Field) ([]*starr.Field, error) {
+	output := make([]*starr.Field, len(fields))
+	for i, f := range fields {
+		output[i].Name = f.Name
+		// check for string paramenters
+		if v, a := f.Value.(string); (sort.SearchStrings(IndexerFieldsString, f.Name) != len(IndexerFieldsString)) && !a {
+			output[i].Value = v
+			continue
+		}
+		// check for int parameters
+		if v, a := f.Value.(int64); (sort.SearchStrings(IndexerFieldsInt, f.Name) != len(IndexerFieldsInt)) && !a {
+			output[i].Value = v
+			continue
+		}
+		// check for bool parameters
+		if v, a := f.Value.(bool); (sort.SearchStrings(IndexerFieldsBool, f.Name) != len(IndexerFieldsBool)) && !a {
+			output[i].Value = v
+			continue
+		}
+		// check for int slice parameters
+		if j := sort.SearchStrings(IndexerFieldsIntSlice, f.Name); j != len(IndexerFieldsIntSlice) {
+			slice := make([]int64, len(f.Value.([]interface{})))
+			var assert bool
+			for k, v := range f.Value.([]interface{}) {
+				slice[k], assert = v.(int64)
+				if !assert {
+					return nil, fmt.Errorf("parameter %s is not of expected type", f.Name)
+				}
+			}
+			output[i].Value = slice
+			continue
+		}
+		// check for float parameters
+		if v, a := f.Value.(float64); (sort.SearchStrings(IndexerFieldsFloat, f.Name) != len(IndexerFieldsFloat)) && !a {
+			output[i].Value = v
+			continue
+		}
+		return nil, fmt.Errorf("parameter %s is not of expected type", f.Name)
+	}
+	return output, nil
+}

--- a/sonarr/indexer_test.go
+++ b/sonarr/indexer_test.go
@@ -1,0 +1,120 @@
+package sonarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/sonarr"
+)
+
+const indexerBody = `{
+	"enableRss": true,
+	"enableAutomaticSearch": true,
+	"enableInteractiveSearch": true,
+	"supportsRss": true,
+	"supportsSearch": true,
+	"protocol": "usenet",
+	"priority": 25,
+	"downloadClientId": 0,
+	"name": "NZBgeek",
+	"fields": [
+	  {
+		"order": 0,
+		"name": "baseUrl",
+		"label": "URL",
+		"value": "https://api.nzbgeek.info",
+		"type": "textbox",
+		"advanced": false
+	  },
+	  {
+		"order": 1,
+		"name": "apiPath",
+		"label": "API Path",
+		"helpText": "Path to the api, usually /api",
+		"value": "/api",
+		"type": "textbox",
+		"advanced": true
+	  }
+	],
+	"implementationName": "Newznab",
+	"implementation": "Newznab",
+	"configContract": "NewznabSettings",
+	"infoLink": "https://wiki.servarr.com/sonarr/supported#newznab",
+	"tags": [],
+	"id": 1
+  }`
+
+func TestGet(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, sonarr.APIver, "indexer/1"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    indexerBody,
+			WithRequest:     nil,
+			WithResponse: &sonarr.IndexerOutput{
+				EnableAutomaticSearch:   true,
+				EnableInteractiveSearch: true,
+				EnableRss:               true,
+				SupportsRss:             true,
+				SupportsSearch:          true,
+				Priority:                25,
+				ID:                      1,
+				ConfigContract:          "NewznabSettings",
+				Implementation:          "Newznab",
+				ImplementationName:      "Newznab",
+				InfoLink:                "https://wiki.servarr.com/sonarr/supported#newznab",
+				Name:                    "NZBgeek",
+				Protocol:                "usenet",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "baseUrl",
+						Label:    "URL",
+						Value:    "https://api.nzbgeek.info",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "apiPath",
+						Label:    "API Path",
+						HelpText: "Path to the api, usually /api",
+						Value:    "/api",
+						Type:     "textbox",
+						Advanced: true,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "indexer/1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*sonarr.IndexerOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetIndexer(1)
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}

--- a/sonarr/indexer_test.go
+++ b/sonarr/indexer_test.go
@@ -45,6 +45,7 @@ const indexerResponseBody = `{
 	"tags": [],
 	"id": 1
   }`
+
 const addIndexer = `{"enableAutomaticSearch":true,"enableInteractiveSearch":true,"enableRss":true,` +
 	`"downloadClientId":0,"priority":25,"configContract":"NewznabSettings","implementation":"Newznab"` +
 	`,"name":"NZBgeek","protocol":"usenet","tags":[],` +

--- a/sonarr/indexerconfig.go
+++ b/sonarr/indexerconfig.go
@@ -1,0 +1,56 @@
+package sonarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strconv"
+)
+
+type IndexerConfig struct {
+	ID              int64 `json:"id"`
+	MaximumSize     int64 `json:"maximumSize"`
+	MinimumAge      int64 `json:"minimumAge"`
+	Retention       int64 `json:"retention"`
+	RssSyncInterval int64 `json:"rssSyncInterval"`
+}
+
+const bpIndexerConfig = APIver + "/config/indexer"
+
+// GetIndexerConfig returns the indexerConfig.
+func (s *Sonarr) GetIndexerConfig() (*IndexerConfig, error) {
+	return s.GetIndexerConfigContext(context.Background())
+}
+
+func (s *Sonarr) GetIndexerConfigContext(ctx context.Context) (*IndexerConfig, error) {
+	var output *IndexerConfig
+
+	if _, err := s.GetInto(ctx, bpIndexerConfig, nil, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(indexerConfig): %w", err)
+	}
+
+	return output, nil
+}
+
+// UpdateIndexerConfig update the single indexerConfig.
+func (s *Sonarr) UpdateIndexerConfig(indexerConfig *IndexerConfig) (*IndexerConfig, error) {
+	return s.UpdateIndexerConfigContext(context.Background(), indexerConfig)
+}
+
+func (s *Sonarr) UpdateIndexerConfigContext(ctx context.Context, indexerConfig *IndexerConfig) (*IndexerConfig, error) {
+	var output IndexerConfig
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(indexerConfig); err != nil {
+		return nil, fmt.Errorf("json.Marshal(indexerConfig): %w", err)
+	}
+
+	uri := path.Join(bpIndexerConfig, strconv.Itoa(int(indexerConfig.ID)))
+	if _, err := s.PutInto(ctx, uri, nil, &body, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(indexerConfig): %w", err)
+	}
+
+	return &output, nil
+}

--- a/sonarr/indexerconfig_test.go
+++ b/sonarr/indexerconfig_test.go
@@ -1,0 +1,120 @@
+package sonarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/sonarr"
+)
+
+const indexerConfigBody = `{
+	"minimumAge": 0,
+	"retention": 0,
+	"maximumSize": 0,
+	"rssSyncInterval": 20,
+	"id": 1
+}`
+
+func TestGetIndexerConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "config/indexer"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   indexerConfigBody,
+			WithResponse: &sonarr.IndexerConfig{
+				ID:              1,
+				MaximumSize:     0,
+				MinimumAge:      0,
+				Retention:       0,
+				RssSyncInterval: 20,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "config/indexer"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*sonarr.IndexerConfig)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetIndexerConfig()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateIndexerConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "202",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "config/indexer/1"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 202,
+			WithRequest: &sonarr.IndexerConfig{
+				ID:              1,
+				MaximumSize:     0,
+				MinimumAge:      0,
+				Retention:       0,
+				RssSyncInterval: 20,
+			},
+			ExpectedRequest: `{"id":1,"maximumSize":0,"minimumAge":0,"retention":0,"rssSyncInterval":20}` + "\n",
+			ResponseBody:    indexerConfigBody,
+			WithResponse: &sonarr.IndexerConfig{
+				ID:              1,
+				MaximumSize:     0,
+				MinimumAge:      0,
+				Retention:       0,
+				RssSyncInterval: 20,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "config/indexer/1"),
+			ExpectedMethod: "PUT",
+			WithRequest: &sonarr.IndexerConfig{
+				ID:              1,
+				MaximumSize:     0,
+				MinimumAge:      0,
+				Retention:       0,
+				RssSyncInterval: 20,
+			},
+			ExpectedRequest: `{"id":1,"maximumSize":0,"minimumAge":0,"retention":0,"rssSyncInterval":20}` + "\n",
+			ResponseStatus:  404,
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*sonarr.IndexerConfig)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateIndexerConfig(test.WithRequest.(*sonarr.IndexerConfig))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}


### PR DESCRIPTION
Hi @davidnewhall,
I'm creating this draft to have few feedbacks before continuing. I'm trying to implement the indexer methods for sonarr.
while the /indexer/config endpoint it's pretty straightforward, I'd like to have your opinion on a couple of points for the /indexer endpoint:

- How to address the `Value` field of `Field` struct? The type of this field isn't consistent, should we pass a generic interface? or is it better to have type assertion based on the actual type? I'd prefer to go with the second option. Hence, I tried to implement a draft with the function `correctIndexerFieldsValue` that could be improved if we follow this approach. I even thought of using a generic type assertion switch, but that could lead to wrong assertion for int/float.
- Should we separate input struct and output struct? Like the `Series` struct, the input doesn't need few of the output fields, even if they are natively used by sonarr. While the `Indexer` struct have only 3-4 fields that can be omitted, the main difference will be in the `Field` struct in which the input needs only 2 (`Type` and `Value`) of 11 fields. For now I draft only one struct for both input and output, but I'm not too picky on this one. If you prefer, we can split it up.

What do you think?

p.s. sorry for the lint, I forgot to run it locally. I'll fix it later.