### PR TITLE
Add movie editor endpoints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,5 +30,10 @@ linters:
     - dupl
     - nlreturn
 
+#linters-settings:
+#  govet:
+#    enable:
+#      - fieldalignment
+
 run:
   timeout: 35m

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module golift.io/starr
 
 go 1.17
 
-require golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b // publicsuffix, cookiejar.
+require golang.org/x/net v0.0.0-20221004154528-8021a29435af // publicsuffix, cookiejar.
 
 // All of this is for the tests.
 require (

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b h1:ZmngSVLe/wycRns9MKikG9OWIEjGcGAkacif7oYQaUY=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20221004154528-8021a29435af h1:wv66FM3rLZGPdxpYL+ApnDe2HzHcTFta3z5nsc13wI4=
+golang.org/x/net v0.0.0-20221004154528-8021a29435af/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pointers.go
+++ b/pointers.go
@@ -1,0 +1,23 @@
+package starr
+
+// String returns a pointer to a string.
+func String(s string) *string {
+	return &s
+}
+
+// True returns a pointer to a true boolean.
+func True() *bool {
+	s := true
+	return &s
+}
+
+// False returns a pointer to a false boolean.
+func False() *bool {
+	s := false
+	return &s
+}
+
+// Int64 returns a pointer to the provided integer.
+func Int64(s int64) *int64 {
+	return &s
+}

--- a/radarr/importlist.go
+++ b/radarr/importlist.go
@@ -14,23 +14,23 @@ const bpImportList = APIver + "/importlist"
 
 // ImportList represents the api/v3/importlist endpoint.
 type ImportList struct {
-	ID                  int64    `json:"id"`
-	Name                string   `json:"name"`
-	Enabled             bool     `json:"enabled"`
-	EnableAuto          bool     `json:"enableAuto"`
-	ShouldMonitor       bool     `json:"shouldMonitor"`
-	SearchOnAdd         bool     `json:"searchOnAdd"`
-	RootFolderPath      string   `json:"rootFolderPath"`
-	QualityProfileID    int64    `json:"qualityProfileId"`
-	MinimumAvailability string   `json:"minimumAvailability"`
-	ListType            string   `json:"listType"`
-	ListOrder           int64    `json:"listOrder"`
-	Fields              []*Field `json:"fields"`
-	ImplementationName  string   `json:"implementationName"`
-	Implementation      string   `json:"implementation"`
-	ConfigContract      string   `json:"configContract"`
-	InfoLink            string   `json:"infoLink"`
-	Tags                []int    `json:"tags"`
+	ID                  int64        `json:"id"`
+	Name                string       `json:"name"`
+	Enabled             bool         `json:"enabled"`
+	EnableAuto          bool         `json:"enableAuto"`
+	ShouldMonitor       bool         `json:"shouldMonitor"`
+	SearchOnAdd         bool         `json:"searchOnAdd"`
+	RootFolderPath      string       `json:"rootFolderPath"`
+	QualityProfileID    int64        `json:"qualityProfileId"`
+	MinimumAvailability Availability `json:"minimumAvailability"`
+	ListType            string       `json:"listType"`
+	ListOrder           int64        `json:"listOrder"`
+	Fields              []*Field     `json:"fields"`
+	ImplementationName  string       `json:"implementationName"`
+	Implementation      string       `json:"implementation"`
+	ConfigContract      string       `json:"configContract"`
+	InfoLink            string       `json:"infoLink"`
+	Tags                []int        `json:"tags"`
 }
 
 // Field is currently only part of ImportList.

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -19,7 +19,7 @@ type Movie struct {
 	ID                    int64               `json:"id"`
 	Title                 string              `json:"title,omitempty"`
 	Path                  string              `json:"path,omitempty"`
-	MinimumAvailability   string              `json:"minimumAvailability,omitempty"`
+	MinimumAvailability   Availability        `json:"minimumAvailability,omitempty"`
 	QualityProfileID      int64               `json:"qualityProfileId,omitempty"`
 	TmdbID                int64               `json:"tmdbId,omitempty"`
 	OriginalTitle         string              `json:"originalTitle,omitempty"`
@@ -101,7 +101,7 @@ type MediaInfo struct {
 type AddMovieInput struct {
 	Title               string           `json:"title,omitempty"`
 	TitleSlug           string           `json:"titleSlug,omitempty"`
-	MinimumAvailability string           `json:"minimumAvailability,omitempty"`
+	MinimumAvailability Availability     `json:"minimumAvailability,omitempty"`
 	RootFolderPath      string           `json:"rootFolderPath"`
 	TmdbID              int64            `json:"tmdbId"`
 	QualityProfileID    int64            `json:"qualityProfileId"`
@@ -138,7 +138,7 @@ type AddMovieOutput struct {
 	Studio                string              `json:"studio"`
 	Path                  string              `json:"path"`
 	QualityProfileID      int64               `json:"qualityProfileId"`
-	MinimumAvailability   string              `json:"minimumAvailability"`
+	MinimumAvailability   Availability        `json:"minimumAvailability"`
 	FolderName            string              `json:"folderName"`
 	Runtime               int                 `json:"runtime"`
 	CleanTitle            string              `json:"cleanTitle"`

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -281,12 +281,15 @@ func (r *Radarr) LookupContext(ctx context.Context, term string) ([]*Movie, erro
 	return output, nil
 }
 
-func (r *Radarr) DeleteMovie(movieID int64) error {
-	return r.DeleteMovieContext(context.Background(), movieID)
+func (r *Radarr) DeleteMovie(movieID int64, deleteFiles, addImportExclusion bool) error {
+	return r.DeleteMovieContext(context.Background(), movieID, deleteFiles, addImportExclusion)
 }
 
-func (r *Radarr) DeleteMovieContext(ctx context.Context, movieID int64) error {
-	req := starr.Request{URI: path.Join(bpMovie, fmt.Sprint(movieID))}
+func (r *Radarr) DeleteMovieContext(ctx context.Context, movieID int64, deleteFiles, addImportExclusion bool) error {
+	req := starr.Request{URI: path.Join(bpMovie, fmt.Sprint(movieID)), Query: make(url.Values)}
+	req.Query.Set("deleteFiles", fmt.Sprint(deleteFiles))
+	req.Query.Set("addImportExclusion", fmt.Sprint(addImportExclusion))
+
 	if err := r.DeleteAny(ctx, req); err != nil {
 		return fmt.Errorf("api.Delete(%s): %w", &req, err)
 	}

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -280,3 +280,16 @@ func (r *Radarr) LookupContext(ctx context.Context, term string) ([]*Movie, erro
 
 	return output, nil
 }
+
+func (r *Radarr) DeleteMovie(movieID int64) error {
+	return r.DeleteMovieContext(context.Background(), movieID)
+}
+
+func (r *Radarr) DeleteMovieContext(ctx context.Context, movieID int64) error {
+	req := starr.Request{URI: path.Join(bpMovie, fmt.Sprint(movieID))}
+	if err := r.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -281,10 +281,12 @@ func (r *Radarr) LookupContext(ctx context.Context, term string) ([]*Movie, erro
 	return output, nil
 }
 
+// DeleteMovie removes a movie from the database. Setting deleteFiles true will delete all content for the movie.
 func (r *Radarr) DeleteMovie(movieID int64, deleteFiles, addImportExclusion bool) error {
 	return r.DeleteMovieContext(context.Background(), movieID, deleteFiles, addImportExclusion)
 }
 
+// DeleteMovieContext removes a movie from the database. Setting deleteFiles true will delete all content for the movie.
 func (r *Radarr) DeleteMovieContext(ctx context.Context, movieID int64, deleteFiles, addImportExclusion bool) error {
 	req := starr.Request{URI: path.Join(bpMovie, fmt.Sprint(movieID)), Query: make(url.Values)}
 	req.Query.Set("deleteFiles", fmt.Sprint(deleteFiles))

--- a/radarr/movieeditor.go
+++ b/radarr/movieeditor.go
@@ -1,0 +1,65 @@
+package radarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"golift.io/starr"
+)
+
+const bpMovieEditor = bpMovie + "/editor"
+
+// EditMovies is the input for the bulk movie editor endpoint.
+// You may use starr.True(), starr.False(), starr.Int64(), and starr.String() to add data to the struct members.
+type EditMovies struct {
+	MovieIDs            []int64 `json:"movieIds"`
+	Monitored           *bool   `json:"monitored,omitempty"`
+	QualityProfileID    *int64  `json:"qualityProfileId,omitempty"`
+	MinimumAvailability *string `json:"minimumAvailability,omitempty"` // tba
+	RootFolderPath      *string `json:"rootFolderPath,omitempty"`      // path
+	Tags                []int   `json:"tags,omitempty"`                // [0]
+	ApplyTags           *string `json:"applyTags,omitempty"`           // add
+	MoveFiles           *bool   `json:"moveFiles,omitempty"`
+	DeleteFiles         *bool   `json:"deleteFiles,omitempty"`
+	AddImportExclusion  *bool   `json:"addImportExclusion,omitempty"`
+}
+
+func (r *Radarr) EditMovies(editMovies *EditMovies) ([]*Movie, error) {
+	return r.EditMoviesContext(context.Background(), editMovies)
+}
+
+func (r *Radarr) EditMoviesContext(ctx context.Context, editMovies *EditMovies) ([]*Movie, error) {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(editMovies); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpMovieEditor, err)
+	}
+
+	var output []*Movie
+
+	req := starr.Request{URI: bpMovieEditor, Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+func (r *Radarr) DeleteMovies(movieIDs []int64) error {
+	return r.DeleteMoviesContext(context.Background(), movieIDs)
+}
+
+func (r *Radarr) DeleteMoviesContext(ctx context.Context, movieIDs []int64) error {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(map[string]interface{}{"movieIds": movieIDs}); err != nil {
+		return fmt.Errorf("json.Marshal(%s): %w", bpMovieEditor, err)
+	}
+
+	req := starr.Request{URI: bpMovieEditor, Body: &body}
+	if err := r.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/radarr/movieeditor.go
+++ b/radarr/movieeditor.go
@@ -11,9 +11,9 @@ import (
 
 const bpMovieEditor = bpMovie + "/editor"
 
-// EditMovies is the input for the bulk movie editor endpoint.
+// BulkEdit is the input for the bulk movie editor endpoint.
 // You may use starr.True(), starr.False(), starr.Int64(), and starr.String() to add data to the struct members.
-type EditMovies struct {
+type BulkEdit struct {
 	MovieIDs            []int64 `json:"movieIds"`
 	Monitored           *bool   `json:"monitored,omitempty"`
 	QualityProfileID    *int64  `json:"qualityProfileId,omitempty"`
@@ -22,15 +22,17 @@ type EditMovies struct {
 	Tags                []int   `json:"tags,omitempty"`                // [0]
 	ApplyTags           *string `json:"applyTags,omitempty"`           // add
 	MoveFiles           *bool   `json:"moveFiles,omitempty"`
-	DeleteFiles         *bool   `json:"deleteFiles,omitempty"`
-	AddImportExclusion  *bool   `json:"addImportExclusion,omitempty"`
+	DeleteFiles         *bool   `json:"deleteFiles,omitempty"`        // delete only
+	AddImportExclusion  *bool   `json:"addImportExclusion,omitempty"` // delete only
 }
 
-func (r *Radarr) EditMovies(editMovies *EditMovies) ([]*Movie, error) {
+// EditMovies allows bulk diting many movies at once.
+func (r *Radarr) EditMovies(editMovies *BulkEdit) ([]*Movie, error) {
 	return r.EditMoviesContext(context.Background(), editMovies)
 }
 
-func (r *Radarr) EditMoviesContext(ctx context.Context, editMovies *EditMovies) ([]*Movie, error) {
+// EditMoviesContext allows bulk diting many movies at once.
+func (r *Radarr) EditMoviesContext(ctx context.Context, editMovies *BulkEdit) ([]*Movie, error) {
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(editMovies); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpMovieEditor, err)
@@ -46,13 +48,15 @@ func (r *Radarr) EditMoviesContext(ctx context.Context, editMovies *EditMovies) 
 	return output, nil
 }
 
-func (r *Radarr) DeleteMovies(movieIDs []int64) error {
-	return r.DeleteMoviesContext(context.Background(), movieIDs)
+// DeleteMovies bulk deletes movies. Can also mark them as excluded, and delete their files.
+func (r *Radarr) DeleteMovies(deleteMovies *BulkEdit) error {
+	return r.DeleteMoviesContext(context.Background(), deleteMovies)
 }
 
-func (r *Radarr) DeleteMoviesContext(ctx context.Context, movieIDs []int64) error {
+// DeleteDeleteMoviesContextMovies bulk deletes movies. Can also mark them as excluded, and delete their files.
+func (r *Radarr) DeleteMoviesContext(ctx context.Context, deleteMovies *BulkEdit) error {
 	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(map[string]interface{}{"movieIds": movieIDs}); err != nil {
+	if err := json.NewEncoder(&body).Encode(deleteMovies); err != nil {
 		return fmt.Errorf("json.Marshal(%s): %w", bpMovieEditor, err)
 	}
 

--- a/radarr/movieeditor.go
+++ b/radarr/movieeditor.go
@@ -13,17 +13,36 @@ const bpMovieEditor = bpMovie + "/editor"
 
 // BulkEdit is the input for the bulk movie editor endpoint.
 // You may use starr.True(), starr.False(), starr.Int64(), and starr.String() to add data to the struct members.
+// Use Availability.Ptr() to add a value to minimum availability, and starr.ApplyTags.Ptr() for apply tags.
 type BulkEdit struct {
-	MovieIDs            []int64 `json:"movieIds"`
-	Monitored           *bool   `json:"monitored,omitempty"`
-	QualityProfileID    *int64  `json:"qualityProfileId,omitempty"`
-	MinimumAvailability *string `json:"minimumAvailability,omitempty"` // tba
-	RootFolderPath      *string `json:"rootFolderPath,omitempty"`      // path
-	Tags                []int   `json:"tags,omitempty"`                // [0]
-	ApplyTags           *string `json:"applyTags,omitempty"`           // add
-	MoveFiles           *bool   `json:"moveFiles,omitempty"`
-	DeleteFiles         *bool   `json:"deleteFiles,omitempty"`        // delete only
-	AddImportExclusion  *bool   `json:"addImportExclusion,omitempty"` // delete only
+	MovieIDs            []int64          `json:"movieIds"`
+	Monitored           *bool            `json:"monitored,omitempty"`
+	QualityProfileID    *int64           `json:"qualityProfileId,omitempty"`
+	MinimumAvailability *Availability    `json:"minimumAvailability,omitempty"` // tba
+	RootFolderPath      *string          `json:"rootFolderPath,omitempty"`      // path
+	Tags                []int            `json:"tags,omitempty"`                // [0]
+	ApplyTags           *starr.ApplyTags `json:"applyTags,omitempty"`           // add
+	MoveFiles           *bool            `json:"moveFiles,omitempty"`
+	DeleteFiles         *bool            `json:"deleteFiles,omitempty"`        // delete only
+	AddImportExclusion  *bool            `json:"addImportExclusion,omitempty"` // delete only
+}
+
+// Availability is an enum used as MinimumAvailability in a few places throughout Radarr.
+type Availability string
+
+// Availability / MinimumAvailability constants.
+// https://radarr.video/docs/api/#/MovieEditor/put_api_v3_movie_editor
+const (
+	AvailabilityToBeAnnounced Availability = "tba"
+	AvailabilityAnnounced     Availability = "announced"
+	AvailabilityInCinemas     Availability = "inCinemas"
+	AvailabilityReleased      Availability = "released"
+	AvailabilityDeleted       Availability = "deleted"
+)
+
+// Ptr returns a pointer to a minimum availability. Useful for a BulkEdit struct.
+func (a Availability) Ptr() *Availability {
+	return &a
 }
 
 // EditMovies allows bulk diting many movies at once.

--- a/radarr/movieeditor_test.go
+++ b/radarr/movieeditor_test.go
@@ -20,7 +20,7 @@ func TestEditMovies(t *testing.T) {
 			ResponseStatus: http.StatusOK,
 			ResponseBody:   `[{"id": 7, "monitored": true},{"id": 3, "monitored": true}]`,
 			WithError:      nil,
-			WithRequest: &radarr.EditMovies{
+			WithRequest: &radarr.BulkEdit{
 				MovieIDs:    []int64{7, 3},
 				Monitored:   starr.True(),
 				DeleteFiles: starr.False(),
@@ -37,7 +37,7 @@ func TestEditMovies(t *testing.T) {
 			t.Parallel()
 			mockServer := test.GetMockServer(t)
 			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
-			output, err := client.EditMovies(test.WithRequest.(*radarr.EditMovies))
+			output, err := client.EditMovies(test.WithRequest.(*radarr.BulkEdit))
 			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})

--- a/radarr/movieeditor_test.go
+++ b/radarr/movieeditor_test.go
@@ -63,3 +63,34 @@ func TestEditMovies(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteMovies(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "movie", "editor"),
+			ResponseStatus: http.StatusOK,
+			WithError:      nil,
+			WithRequest: &radarr.BulkEdit{
+				MovieIDs:    []int64{7, 3},
+				Monitored:   starr.False(),
+				DeleteFiles: starr.True(),
+			},
+			ExpectedRequest: `{"movieIds":[7,3],"monitored":false,"deleteFiles":true}` + "\n",
+			ExpectedMethod:  http.MethodDelete,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteMovies(test.WithRequest.(*radarr.BulkEdit))
+			assert.ErrorIs(t, err, test.WithError, "the wrong error was returned")
+		})
+	}
+}

--- a/radarr/movieeditor_test.go
+++ b/radarr/movieeditor_test.go
@@ -1,0 +1,45 @@
+package radarr_test
+
+import (
+	"net/http"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+)
+
+func TestEditMovies(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "movie", "editor"),
+			ResponseStatus: http.StatusOK,
+			ResponseBody:   `[{"id": 7, "monitored": true},{"id": 3, "monitored": true}]`,
+			WithError:      nil,
+			WithRequest: &radarr.EditMovies{
+				MovieIDs:    []int64{7, 3},
+				Monitored:   starr.True(),
+				DeleteFiles: starr.False(),
+			},
+			ExpectedRequest: `{"movieIds":[7,3],"monitored":true,"deleteFiles":false}` + "\n",
+			ExpectedMethod:  http.MethodPut,
+			WithResponse:    []*radarr.Movie{{ID: 7, Monitored: true}, {ID: 3, Monitored: true}},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.EditMovies(test.WithRequest.(*radarr.EditMovies))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}

--- a/shared.go
+++ b/shared.go
@@ -224,3 +224,19 @@ func (d *PlayTime) MarshalJSON() ([]byte, error) {
 }
 
 var _ json.Unmarshaler = (*PlayTime)(nil)
+
+// ApplyTags is an enum used as an input for Bulk editors, and perhaps other places.
+type ApplyTags string
+
+// ApplyTags enum constants. Use these as inputs for "ApplyTags" member values.
+// Schema doc'd here: https://radarr.video/docs/api/#/MovieEditor/put_api_v3_movie_editor
+const (
+	TagsAdd     ApplyTags = "add"
+	TagsRemove  ApplyTags = "remove"
+	TagsReplace ApplyTags = "replace"
+)
+
+// Ptr returns a pointer to an apply tags value. Useful for a BulkEdit struct.
+func (a ApplyTags) Ptr() *ApplyTags {
+	return &a
+}

--- a/test_methods.go
+++ b/test_methods.go
@@ -40,7 +40,7 @@ func (test *TestMockData) GetMockServer(t *testing.T) *httptest.Server {
 		assert.EqualValues(t, test.ExpectedPath, req.URL.String())
 		writer.WriteHeader(test.ResponseStatus)
 
-		assert.EqualValues(t, req.Method, test.ExpectedMethod)
+		assert.EqualValues(t, test.ExpectedMethod, req.Method)
 
 		body, err := io.ReadAll(req.Body)
 		assert.NoError(t, err)


### PR DESCRIPTION
Adds movie editor endpoint.
Adds movie delete and bulk delete endpoints.
Closes #68. @NCRoxas, can you test this?

```go
edit := &radarr.BulkEdit{
    MovieIDs:    []int64{7, 3},
    Monitored:   starr.True(),
    DeleteFiles: starr.False(),
}
movies, err := r.EditMovies(edit)
```