### PR TITLE
Add Calendar methods: sonarr & readarr

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ issues:
         - nonamedreturns
       path: 'starrcmd/'
     - linters:
+        - gochecknoglobals
         - forcetypeassert
         - funlen
         - maintidx # uhg.

--- a/radarr/naming_test.go
+++ b/radarr/naming_test.go
@@ -79,7 +79,7 @@ func TestUpdateNaming(t *testing.T) {
 				ID:                       1,
 				ReplaceIllegalCharacters: true,
 			},
-			ExpectedRequest: `{"replaceIllegalCharacters":true,"id":1}` + "\n",
+			ExpectedRequest: `{"replaceIllegalCharacters":true,"id":1,"standardMovieFormat":"","movieFolderFormat":""}` + "\n",
 			ResponseBody:    namingBody,
 			WithResponse: &radarr.Naming{
 				ID:                       1,
@@ -101,7 +101,7 @@ func TestUpdateNaming(t *testing.T) {
 				ID:                       1,
 				ReplaceIllegalCharacters: true,
 			},
-			ExpectedRequest: `{"replaceIllegalCharacters":true,"id":1}` + "\n",
+			ExpectedRequest: `{"replaceIllegalCharacters":true,"id":1,"standardMovieFormat":"","movieFolderFormat":""}` + "\n",
 			ResponseStatus:  404,
 			ResponseBody:    `{"message": "NotFound"}`,
 			WithError:       starr.ErrInvalidStatusCode,

--- a/readarr/author.go
+++ b/readarr/author.go
@@ -16,31 +16,35 @@ const bpAuthor = APIver + "/author"
 
 // Author is the /api/v1/author endpoint.
 type Author struct {
-	ID                int64          `json:"id"`
-	Status            string         `json:"status,omitempty"`
-	AuthorName        string         `json:"authorName,omitempty"`
-	ForeignAuthorID   string         `json:"foreignAuthorId,omitempty"`
-	TitleSlug         string         `json:"titleSlug,omitempty"`
-	Overview          string         `json:"overview,omitempty"`
-	Links             []*starr.Link  `json:"links,omitempty"`
-	Images            []*starr.Image `json:"images,omitempty"`
-	Path              string         `json:"path,omitempty"`
-	QualityProfileID  int            `json:"qualityProfileId,omitempty"`
-	MetadataProfileID int            `json:"metadataProfileId,omitempty"`
-	Genres            []interface{}  `json:"genres,omitempty"`
-	CleanName         string         `json:"cleanName,omitempty"`
-	SortName          string         `json:"sortName,omitempty"`
-	Tags              []int          `json:"tags,omitempty"`
-	Added             time.Time      `json:"added,omitempty"`
-	Ratings           *starr.Ratings `json:"ratings,omitempty"`
-	Statistics        *Statistics    `json:"statistics,omitempty"`
-	LastBook          *AuthorBook    `json:"lastBook,omitempty"`
-	NextBook          *AuthorBook    `json:"nextBook,omitempty"`
-	Ended             bool           `json:"ended,omitempty"`
-	Monitored         bool           `json:"monitored"`
+	ID                  int64          `json:"id"`
+	Status              string         `json:"status,omitempty"`
+	AuthorName          string         `json:"authorName,omitempty"`
+	ForeignAuthorID     string         `json:"foreignAuthorId,omitempty"`
+	TitleSlug           string         `json:"titleSlug,omitempty"`
+	Overview            string         `json:"overview,omitempty"`
+	Links               []*starr.Link  `json:"links,omitempty"`
+	Images              []*starr.Image `json:"images,omitempty"`
+	Path                string         `json:"path,omitempty"`
+	QualityProfileID    int            `json:"qualityProfileId,omitempty"`
+	MetadataProfileID   int            `json:"metadataProfileId,omitempty"`
+	Genres              []interface{}  `json:"genres,omitempty"`
+	CleanName           string         `json:"cleanName,omitempty"`
+	SortName            string         `json:"sortName,omitempty"`
+	Tags                []int          `json:"tags,omitempty"`
+	Added               time.Time      `json:"added,omitempty"`
+	Ratings             *starr.Ratings `json:"ratings,omitempty"`
+	Statistics          *Statistics    `json:"statistics,omitempty"`
+	LastBook            *AuthorBook    `json:"lastBook,omitempty"`
+	NextBook            *AuthorBook    `json:"nextBook,omitempty"`
+	Ended               bool           `json:"ended,omitempty"`
+	Monitored           bool           `json:"monitored"`
+	AuthorMetadataID    int64          `json:"authorMetadataId"`
+	AuthorNameLastFirst string         `json:"authorNameLastFirst"`
+	MonitorNewItems     string         `json:"monitorNewItems"`
+	SortNameLastFirst   string         `json:"sortNameLastFirst"`
 }
 
-// AuthorBook is part of an Author.
+// AuthorBook is part of an Author, and is very different from a normal Book type.
 type AuthorBook struct {
 	ID               int64           `json:"id"`
 	AuthorMetadataID int             `json:"authorMetadataId"`
@@ -49,7 +53,7 @@ type AuthorBook struct {
 	Title            string          `json:"title"`
 	ReleaseDate      time.Time       `json:"releaseDate"`
 	Links            []*starr.Link   `json:"links"`
-	Genres           []interface{}   `json:"genres"`
+	Genres           []string        `json:"genres"`
 	Ratings          *starr.Ratings  `json:"ratings"`
 	CleanTitle       string          `json:"cleanTitle"`
 	Monitored        bool            `json:"monitored"`

--- a/readarr/author.go
+++ b/readarr/author.go
@@ -27,7 +27,7 @@ type Author struct {
 	Path                string         `json:"path,omitempty"`
 	QualityProfileID    int            `json:"qualityProfileId,omitempty"`
 	MetadataProfileID   int            `json:"metadataProfileId,omitempty"`
-	Genres              []interface{}  `json:"genres,omitempty"`
+	Genres              []string       `json:"genres,omitempty"`
 	CleanName           string         `json:"cleanName,omitempty"`
 	SortName            string         `json:"sortName,omitempty"`
 	Tags                []int          `json:"tags,omitempty"`

--- a/readarr/calendar.go
+++ b/readarr/calendar.go
@@ -46,13 +46,13 @@ type CalendarInput struct {
 }
 
 // GetCalendar returns calendars based on filters.
-func (r *Readarr) GetCalendar(filter CalendarInput) ([]*Calendar, error) {
+func (r *Readarr) GetCalendar(filter CalendarInput) ([]*Book, error) {
 	return r.GetCalendarContext(context.Background(), filter)
 }
 
 // GetCalendarContext returns calendars based on filters.
-func (r *Readarr) GetCalendarContext(ctx context.Context, filter CalendarInput) ([]*Calendar, error) {
-	var output []*Calendar
+func (r *Readarr) GetCalendarContext(ctx context.Context, filter CalendarInput) ([]*Book, error) {
+	var output []*Book
 
 	req := starr.Request{URI: bpCalendar, Query: make(url.Values)}
 
@@ -80,13 +80,13 @@ func (r *Readarr) GetCalendarContext(ctx context.Context, filter CalendarInput) 
 }
 
 // GetCalendarID returns a single calendar by ID.
-func (r *Readarr) GetCalendarID(calendarID int64) (*Calendar, error) {
+func (r *Readarr) GetCalendarID(calendarID int64) (*Book, error) {
 	return r.GetCalendarIDContext(context.Background(), calendarID)
 }
 
 // GetCalendarIDContext returns a single calendar by ID.
-func (r *Readarr) GetCalendarIDContext(ctx context.Context, calendarID int64) (*Calendar, error) {
-	var output *Calendar
+func (r *Readarr) GetCalendarIDContext(ctx context.Context, calendarID int64) (*Book, error) {
+	var output *Book
 
 	req := starr.Request{URI: path.Join(bpCalendar, fmt.Sprint(calendarID))}
 	if err := r.GetInto(ctx, req, &output); err != nil {

--- a/readarr/calendar.go
+++ b/readarr/calendar.go
@@ -13,32 +13,9 @@ import (
 // Define Base Path for Calendar queries.
 const bpCalendar = APIver + "/calendar"
 
-type Calendar struct {
-	Added          time.Time      `json:"added"`
-	AnyEditionOk   bool           `json:"anyEditionOk"`
-	Author         *Author        `json:"author"`
-	AuthorID       int64          `json:"authorId"`
-	AuthorTitle    string         `json:"authorTitle"`
-	Disambiguation string         `json:"disambiguation"`
-	ForeignBookID  string         `json:"foreignBookId"`
-	Genres         []string       `json:"genres"`
-	Grabbed        bool           `json:"grabbed"`
-	ID             int64          `json:"id"`
-	Images         []*starr.Image `json:"images"`
-	Links          []*starr.Link  `json:"links"`
-	Monitored      bool           `json:"monitored"`
-	PageCount      int            `json:"pageCount"`
-	Ratings        *starr.Ratings `json:"ratings"`
-	ReleaseDate    time.Time      `json:"releaseDate"`
-	SeriesTitle    string         `json:"seriesTitle"`
-	Statistics     *Statistics    `json:"statistics"`
-	Title          string         `json:"title"`
-	TitleSlug      string         `json:"titleSlug"`
-}
-
-// CalendarInput defines the filters for fetching calendar items.
+// Calendar defines the filters for fetching calendar items.
 // Start and End are required. Use starr.True() and starr.False() to fill in the booleans.
-type CalendarInput struct {
+type Calendar struct {
 	Start         time.Time
 	End           time.Time
 	Unmonitored   *bool
@@ -46,12 +23,12 @@ type CalendarInput struct {
 }
 
 // GetCalendar returns calendars based on filters.
-func (r *Readarr) GetCalendar(filter CalendarInput) ([]*Book, error) {
+func (r *Readarr) GetCalendar(filter Calendar) ([]*Book, error) {
 	return r.GetCalendarContext(context.Background(), filter)
 }
 
 // GetCalendarContext returns calendars based on filters.
-func (r *Readarr) GetCalendarContext(ctx context.Context, filter CalendarInput) ([]*Book, error) {
+func (r *Readarr) GetCalendarContext(ctx context.Context, filter Calendar) ([]*Book, error) {
 	var output []*Book
 
 	req := starr.Request{URI: bpCalendar, Query: make(url.Values)}

--- a/readarr/calendar.go
+++ b/readarr/calendar.go
@@ -14,12 +14,11 @@ import (
 const bpCalendar = APIver + "/calendar"
 
 // Calendar defines the filters for fetching calendar items.
-// Start and End are required. Use starr.True() and starr.False() to fill in the booleans.
 type Calendar struct {
 	Start         time.Time
 	End           time.Time
-	Unmonitored   *bool
-	IncludeAuthor *bool
+	Unmonitored   bool
+	IncludeAuthor bool
 }
 
 // GetCalendar returns calendars based on filters.
@@ -32,6 +31,8 @@ func (r *Readarr) GetCalendarContext(ctx context.Context, filter Calendar) ([]*B
 	var output []*Book
 
 	req := starr.Request{URI: bpCalendar, Query: make(url.Values)}
+	req.Query.Add("unmonitored", fmt.Sprint(filter.Unmonitored))
+	req.Query.Add("includeAuthor", fmt.Sprint(filter.IncludeAuthor))
 
 	if !filter.Start.IsZero() {
 		req.Query.Add("start", filter.Start.UTC().Format(starr.CalendarTimeFilterFormat))
@@ -39,14 +40,6 @@ func (r *Readarr) GetCalendarContext(ctx context.Context, filter Calendar) ([]*B
 
 	if !filter.End.IsZero() {
 		req.Query.Add("end", filter.End.UTC().Format(starr.CalendarTimeFilterFormat))
-	}
-
-	if filter.Unmonitored != nil {
-		req.Query.Add("unmonitored", fmt.Sprint(*filter.Unmonitored))
-	}
-
-	if filter.IncludeAuthor != nil {
-		req.Query.Add("includeAuthor", fmt.Sprint(*filter.IncludeAuthor))
 	}
 
 	if err := r.GetInto(ctx, req, &output); err != nil {

--- a/readarr/calendar.go
+++ b/readarr/calendar.go
@@ -1,0 +1,97 @@
+package readarr
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+	"time"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for Calendar queries.
+const bpCalendar = APIver + "/calendar"
+
+type Calendar struct {
+	Added          time.Time      `json:"added"`
+	AnyEditionOk   bool           `json:"anyEditionOk"`
+	Author         *Author        `json:"author"`
+	AuthorID       int64          `json:"authorId"`
+	AuthorTitle    string         `json:"authorTitle"`
+	Disambiguation string         `json:"disambiguation"`
+	ForeignBookID  string         `json:"foreignBookId"`
+	Genres         []string       `json:"genres"`
+	Grabbed        bool           `json:"grabbed"`
+	ID             int64          `json:"id"`
+	Images         []*starr.Image `json:"images"`
+	Links          []*starr.Link  `json:"links"`
+	Monitored      bool           `json:"monitored"`
+	PageCount      int            `json:"pageCount"`
+	Ratings        *starr.Ratings `json:"ratings"`
+	ReleaseDate    time.Time      `json:"releaseDate"`
+	SeriesTitle    string         `json:"seriesTitle"`
+	Statistics     *Statistics    `json:"statistics"`
+	Title          string         `json:"title"`
+	TitleSlug      string         `json:"titleSlug"`
+}
+
+// CalendarInput defines the filters for fetching calendar items.
+// Start and End are required. Use starr.True() and starr.False() to fill in the booleans.
+type CalendarInput struct {
+	Start         time.Time
+	End           time.Time
+	Unmonitored   *bool
+	IncludeAuthor *bool
+}
+
+// GetCalendar returns calendars based on filters.
+func (r *Readarr) GetCalendar(filter CalendarInput) ([]*Calendar, error) {
+	return r.GetCalendarContext(context.Background(), filter)
+}
+
+// GetCalendarContext returns calendars based on filters.
+func (r *Readarr) GetCalendarContext(ctx context.Context, filter CalendarInput) ([]*Calendar, error) {
+	var output []*Calendar
+
+	req := starr.Request{URI: bpCalendar, Query: make(url.Values)}
+
+	if !filter.Start.IsZero() {
+		req.Query.Add("start", filter.Start.UTC().Format(starr.CalendarTimeFilterFormat))
+	}
+
+	if !filter.End.IsZero() {
+		req.Query.Add("end", filter.End.UTC().Format(starr.CalendarTimeFilterFormat))
+	}
+
+	if filter.Unmonitored != nil {
+		req.Query.Add("unmonitored", fmt.Sprint(*filter.Unmonitored))
+	}
+
+	if filter.IncludeAuthor != nil {
+		req.Query.Add("includeAuthor", fmt.Sprint(*filter.IncludeAuthor))
+	}
+
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetCalendarID returns a single calendar by ID.
+func (r *Readarr) GetCalendarID(calendarID int64) (*Calendar, error) {
+	return r.GetCalendarIDContext(context.Background(), calendarID)
+}
+
+// GetCalendarIDContext returns a single calendar by ID.
+func (r *Readarr) GetCalendarIDContext(ctx context.Context, calendarID int64) (*Calendar, error) {
+	var output *Calendar
+
+	req := starr.Request{URI: path.Join(bpCalendar, fmt.Sprint(calendarID))}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}

--- a/readarr/calendar_test.go
+++ b/readarr/calendar_test.go
@@ -120,7 +120,7 @@ func TestGetCalendar(t *testing.T) {
 				"&unmonitored=true",
 			ResponseStatus: http.StatusOK,
 			ResponseBody:   `[` + testCalendarJSON + `]`,
-			WithRequest: readarr.CalendarInput{
+			WithRequest: readarr.Calendar{
 				Start:         time.Unix(1582172420, 0),
 				End:           time.Unix(1582172420, 0),
 				Unmonitored:   starr.True(),
@@ -140,7 +140,7 @@ func TestGetCalendar(t *testing.T) {
 			ResponseBody:   `{"message": "NotFound"}`,
 			WithError:      starr.ErrInvalidStatusCode,
 			ExpectedMethod: http.MethodGet,
-			WithRequest: readarr.CalendarInput{
+			WithRequest: readarr.Calendar{
 				Start:       time.Unix(1582172420, 0),
 				End:         time.Unix(1582172420, 0),
 				Unmonitored: starr.True(),
@@ -155,7 +155,7 @@ func TestGetCalendar(t *testing.T) {
 			t.Parallel()
 			mockServer := test.GetMockServer(t)
 			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
-			output, err := client.GetCalendar(test.WithRequest.(readarr.CalendarInput))
+			output, err := client.GetCalendar(test.WithRequest.(readarr.Calendar))
 			assert.ErrorIs(t, err, test.WithError, "the wrong error was returned")
 			assert.EqualValues(t, test.WithResponse, output, "make sure ResponseBody and WithResponse are a match")
 		})

--- a/readarr/calendar_test.go
+++ b/readarr/calendar_test.go
@@ -1,0 +1,202 @@
+package readarr_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/readarr"
+)
+
+var testCalendarJSON = `{
+	"title": "The Invitation",
+	"authorTitle": "foley, lucy The Invitation",
+	"seriesTitle": "",
+	"disambiguation": "",
+	"authorId": 1,
+	"foreignBookId": "46232124",
+	"titleSlug": "46232124",
+	"monitored": true,
+	"anyEditionOk": true,
+	"ratings": {
+	  "votes": 4797,
+	  "value": 3.67,
+	  "popularity": 17604.989999999998
+	},
+	"releaseDate": "2016-08-02T07:00:00Z",
+	"pageCount": 432,
+	"genres": [
+	  "historical-fiction",
+	  "fiction",
+	  "romance",
+	  "italy"
+	],
+	"images": [
+	  {
+		"url": "/readarr/MediaCover/Books/1/cover.jpg?lastWrite=637735196543077695",
+		"coverType": "cover",
+		"extension": ".jpg"
+	  }
+	],
+	"links": [
+	  {
+		"url": "https://www.goodreads.com/work/editions/46232124",
+		"name": "Goodreads Editions"
+	  },
+	  {
+		"url": "https://www.goodreads.com/book/show/28118525-the-invitation",
+		"name": "Goodreads Book"
+	  }
+	],
+	"statistics": {
+	  "bookFileCount": 0,
+	  "bookCount": 1,
+	  "totalBookCount": 1,
+	  "sizeOnDisk": 0,
+	  "percentOfBooks": 0
+	},
+	"added": "2020-09-29T04:47:05Z",
+	"grabbed": false,
+	"id": 1
+  }`
+
+// This matches the json above.
+var testCalendarStruct = readarr.Calendar{
+	Added:          time.Date(2020, time.September, 29, 4, 47, 5, 0, time.UTC),
+	AnyEditionOk:   true,
+	Author:         nil,
+	AuthorID:       1,
+	AuthorTitle:    "foley, lucy The Invitation",
+	Disambiguation: "",
+	ForeignBookID:  "46232124",
+	Genres:         []string{"historical-fiction", "fiction", "romance", "italy"},
+	Grabbed:        false,
+	ID:             1,
+	Images: []*starr.Image{{
+		URL:       "/readarr/MediaCover/Books/1/cover.jpg?lastWrite=637735196543077695",
+		CoverType: "cover",
+		Extension: ".jpg",
+	}},
+	Links: []*starr.Link{{
+		URL:  "https://www.goodreads.com/work/editions/46232124",
+		Name: "Goodreads Editions",
+	}, {
+		URL:  "https://www.goodreads.com/book/show/28118525-the-invitation",
+		Name: "Goodreads Book",
+	}},
+	Monitored: true,
+	PageCount: 432,
+	Ratings: &starr.Ratings{
+		Votes:      4797,
+		Value:      3.67,
+		Popularity: 17604.989999999998,
+	},
+	ReleaseDate: time.Date(2016, time.August, 2, 7, 0, 0, 0, time.UTC),
+	SeriesTitle: "",
+	Statistics: &readarr.Statistics{
+		BookFileCount:      0,
+		BookCount:          1,
+		AvailableBookCount: 0,
+		TotalBookCount:     1,
+		SizeOnDisk:         0,
+		PercentOfBooks:     0,
+	},
+	Title:     "The Invitation",
+	TitleSlug: "46232124",
+}
+
+func TestGetCalendar(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name: "200",
+			ExpectedPath: "/api/v1/calendar" +
+				"?end=2020-02-20T04%3A20%3A20.000Z" +
+				"&includeAuthor=false" +
+				"&start=2020-02-20T04%3A20%3A20.000Z" +
+				"&unmonitored=true",
+			ResponseStatus: http.StatusOK,
+			ResponseBody:   `[` + testCalendarJSON + `]`,
+			WithRequest: readarr.CalendarInput{
+				Start:         time.Unix(1582172420, 0),
+				End:           time.Unix(1582172420, 0),
+				Unmonitored:   starr.True(),
+				IncludeAuthor: starr.False(),
+			},
+			WithError:      nil,
+			ExpectedMethod: http.MethodGet,
+			WithResponse:   []*readarr.Calendar{&testCalendarStruct},
+		},
+		{
+			Name: "404",
+			ExpectedPath: "/api/v1/calendar" +
+				"?end=2020-02-20T04%3A20%3A20.000Z" +
+				"&start=2020-02-20T04%3A20%3A20.000Z" +
+				"&unmonitored=true",
+			ResponseStatus: http.StatusNotFound,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			ExpectedMethod: http.MethodGet,
+			WithRequest: readarr.CalendarInput{
+				Start:       time.Unix(1582172420, 0),
+				End:         time.Unix(1582172420, 0),
+				Unmonitored: starr.True(),
+			},
+			WithResponse: []*readarr.Calendar(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetCalendar(test.WithRequest.(readarr.CalendarInput))
+			assert.ErrorIs(t, err, test.WithError, "the wrong error was returned")
+			assert.EqualValues(t, test.WithResponse, output, "make sure ResponseBody and WithResponse are a match")
+		})
+	}
+}
+
+func TestGetCalendarID(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   "/api/v1/calendar/1",
+			ResponseStatus: http.StatusOK,
+			ResponseBody:   testCalendarJSON,
+			WithRequest:    int64(1),
+			WithError:      nil,
+			ExpectedMethod: http.MethodGet,
+			WithResponse:   &testCalendarStruct,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   "/api/v1/calendar/1",
+			ResponseStatus: http.StatusNotFound,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			ExpectedMethod: http.MethodGet,
+			WithRequest:    int64(1),
+			WithResponse:   (*readarr.Calendar)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetCalendarID(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "the wrong error was returned")
+			assert.EqualValues(t, test.WithResponse, output, "make sure ResponseBody and WithResponse are a match")
+		})
+	}
+}

--- a/readarr/calendar_test.go
+++ b/readarr/calendar_test.go
@@ -63,7 +63,7 @@ var testCalendarJSON = `{
   }`
 
 // This matches the json above.
-var testCalendarStruct = readarr.Calendar{
+var testCalendarStruct = readarr.Book{
 	Added:          time.Date(2020, time.September, 29, 4, 47, 5, 0, time.UTC),
 	AnyEditionOk:   true,
 	Author:         nil,
@@ -128,7 +128,7 @@ func TestGetCalendar(t *testing.T) {
 			},
 			WithError:      nil,
 			ExpectedMethod: http.MethodGet,
-			WithResponse:   []*readarr.Calendar{&testCalendarStruct},
+			WithResponse:   []*readarr.Book{&testCalendarStruct},
 		},
 		{
 			Name: "404",
@@ -145,7 +145,7 @@ func TestGetCalendar(t *testing.T) {
 				End:         time.Unix(1582172420, 0),
 				Unmonitored: starr.True(),
 			},
-			WithResponse: []*readarr.Calendar(nil),
+			WithResponse: []*readarr.Book(nil),
 		},
 	}
 
@@ -184,7 +184,7 @@ func TestGetCalendarID(t *testing.T) {
 			WithError:      starr.ErrInvalidStatusCode,
 			ExpectedMethod: http.MethodGet,
 			WithRequest:    int64(1),
-			WithResponse:   (*readarr.Calendar)(nil),
+			WithResponse:   (*readarr.Book)(nil),
 		},
 	}
 

--- a/readarr/calendar_test.go
+++ b/readarr/calendar_test.go
@@ -123,8 +123,8 @@ func TestGetCalendar(t *testing.T) {
 			WithRequest: readarr.Calendar{
 				Start:         time.Unix(1582172420, 0),
 				End:           time.Unix(1582172420, 0),
-				Unmonitored:   starr.True(),
-				IncludeAuthor: starr.False(),
+				Unmonitored:   true,
+				IncludeAuthor: false,
 			},
 			WithError:      nil,
 			ExpectedMethod: http.MethodGet,
@@ -134,6 +134,7 @@ func TestGetCalendar(t *testing.T) {
 			Name: "404",
 			ExpectedPath: "/api/v1/calendar" +
 				"?end=2020-02-20T04%3A20%3A20.000Z" +
+				"&includeAuthor=false" +
 				"&start=2020-02-20T04%3A20%3A20.000Z" +
 				"&unmonitored=true",
 			ResponseStatus: http.StatusNotFound,
@@ -143,7 +144,7 @@ func TestGetCalendar(t *testing.T) {
 			WithRequest: readarr.Calendar{
 				Start:       time.Unix(1582172420, 0),
 				End:         time.Unix(1582172420, 0),
-				Unmonitored: starr.True(),
+				Unmonitored: true,
 			},
 			WithResponse: []*readarr.Book(nil),
 		},

--- a/shared.go
+++ b/shared.go
@@ -60,6 +60,9 @@ func ClientWithDebug(timeout time.Duration, verifySSL bool, logConfig debuglog.C
 	return client
 }
 
+// CalendarTimeFilterFormat is the Go time format the calendar expects the filter to be in.
+const CalendarTimeFilterFormat = "2006-01-02T03:04:05.000Z"
+
 // StatusMessage represents the status of the item. All apps use this.
 type StatusMessage struct {
 	Title    string   `json:"title"`

--- a/sonarr/calendar.go
+++ b/sonarr/calendar.go
@@ -13,37 +13,9 @@ import (
 // Define Base Path for Calendar queries.
 const bpCalendar = APIver + "/calendar"
 
-// Calendar represents the data that may be returned from the calendar endpoint.
-type Calendar struct {
-	AbsoluteEpisodeNumber      int            `json:"absoluteEpisodeNumber"`
-	AirDate                    string         `json:"airDate"`
-	AirDateUtc                 time.Time      `json:"airDateUtc"`
-	EndTime                    time.Time      `json:"endTime"`
-	EpisodeFile                *EpisodeFile   `json:"episodeFile"`
-	EpisodeFileID              int64          `json:"episodeFileId"`
-	EpisodeNumber              int            `json:"episodeNumber"`
-	GrabDate                   time.Time      `json:"grabDate"`
-	Grabbed                    bool           `json:"grabbed"`
-	HasFile                    bool           `json:"hasFile"`
-	ID                         int64          `json:"id"`
-	Images                     []*starr.Image `json:"images,omitempty"`
-	Monitored                  bool           `json:"monitored"`
-	Overview                   string         `json:"overview"`
-	SceneAbsoluteEpisodeNumber int            `json:"sceneAbsoluteEpisodeNumber"`
-	SceneEpisodeNumber         int            `json:"sceneEpisodeNumber"`
-	SceneSeasonNumber          int            `json:"sceneSeasonNumber"`
-	SeasonNumber               int            `json:"seasonNumber"`
-	Series                     *Series        `json:"series"`
-	SeriesID                   int64          `json:"seriesId"`
-	SeriesTitle                string         `json:"seriesTitle"`
-	Title                      string         `json:"title"`
-	TvdbID                     int64          `json:"tvdbId"`
-	UnverifiedSceneNumbering   bool           `json:"unverifiedSceneNumbering"`
-}
-
-// CalendarInput defines the filters for fetching calendar items.
+// Calendar defines the filters for fetching calendar items.
 // Start and End are required. Use starr.True() and starr.False() to fill in the booleans.
-type CalendarInput struct {
+type Calendar struct {
 	Start                time.Time
 	End                  time.Time
 	Unmonitored          *bool
@@ -53,13 +25,13 @@ type CalendarInput struct {
 }
 
 // GetCalendar returns calendars based on filters.
-func (s *Sonarr) GetCalendar(filter CalendarInput) ([]*Calendar, error) {
+func (s *Sonarr) GetCalendar(filter Calendar) ([]*Episode, error) {
 	return s.GetCalendarContext(context.Background(), filter)
 }
 
 // GetCalendarContext returns calendars based on filters.
-func (s *Sonarr) GetCalendarContext(ctx context.Context, filter CalendarInput) ([]*Calendar, error) {
-	var output []*Calendar
+func (s *Sonarr) GetCalendarContext(ctx context.Context, filter Calendar) ([]*Episode, error) {
+	var output []*Episode
 
 	req := starr.Request{URI: bpCalendar, Query: make(url.Values)}
 
@@ -95,13 +67,13 @@ func (s *Sonarr) GetCalendarContext(ctx context.Context, filter CalendarInput) (
 }
 
 // GetCalendarID returns a single calendar by ID.
-func (s *Sonarr) GetCalendarID(calendarID int64) (*Calendar, error) {
+func (s *Sonarr) GetCalendarID(calendarID int64) (*Episode, error) {
 	return s.GetCalendarIDContext(context.Background(), calendarID)
 }
 
 // GetCalendarIDContext returns a single calendar by ID.
-func (s *Sonarr) GetCalendarIDContext(ctx context.Context, calendarID int64) (*Calendar, error) {
-	var output *Calendar
+func (s *Sonarr) GetCalendarIDContext(ctx context.Context, calendarID int64) (*Episode, error) {
+	var output *Episode
 
 	req := starr.Request{URI: path.Join(bpCalendar, fmt.Sprint(calendarID))}
 	if err := s.GetInto(ctx, req, &output); err != nil {

--- a/sonarr/calendar.go
+++ b/sonarr/calendar.go
@@ -14,14 +14,13 @@ import (
 const bpCalendar = APIver + "/calendar"
 
 // Calendar defines the filters for fetching calendar items.
-// Start and End are required. Use starr.True() and starr.False() to fill in the booleans.
 type Calendar struct {
 	Start                time.Time
 	End                  time.Time
-	Unmonitored          *bool
-	IncludeSeries        *bool
-	IncludeEpisodeFile   *bool
-	IncludeEpisodeImages *bool
+	Unmonitored          bool
+	IncludeSeries        bool
+	IncludeEpisodeFile   bool
+	IncludeEpisodeImages bool
 }
 
 // GetCalendar returns calendars based on filters.
@@ -34,6 +33,10 @@ func (s *Sonarr) GetCalendarContext(ctx context.Context, filter Calendar) ([]*Ep
 	var output []*Episode
 
 	req := starr.Request{URI: bpCalendar, Query: make(url.Values)}
+	req.Query.Add("unmonitored", fmt.Sprint(filter.Unmonitored))
+	req.Query.Add("includeSeries", fmt.Sprint(filter.IncludeSeries))
+	req.Query.Add("includeEpisodeFile", fmt.Sprint(filter.IncludeEpisodeFile))
+	req.Query.Add("includeEpisodeImages", fmt.Sprint(filter.IncludeEpisodeImages))
 
 	if !filter.Start.IsZero() {
 		req.Query.Add("start", filter.Start.UTC().Format(starr.CalendarTimeFilterFormat))
@@ -41,22 +44,6 @@ func (s *Sonarr) GetCalendarContext(ctx context.Context, filter Calendar) ([]*Ep
 
 	if !filter.End.IsZero() {
 		req.Query.Add("end", filter.End.UTC().Format(starr.CalendarTimeFilterFormat))
-	}
-
-	if filter.Unmonitored != nil {
-		req.Query.Add("unmonitored", fmt.Sprint(*filter.Unmonitored))
-	}
-
-	if filter.IncludeSeries != nil {
-		req.Query.Add("includeSeries", fmt.Sprint(*filter.IncludeSeries))
-	}
-
-	if filter.IncludeEpisodeFile != nil {
-		req.Query.Add("includeEpisodeFile", fmt.Sprint(*filter.IncludeEpisodeFile))
-	}
-
-	if filter.IncludeEpisodeImages != nil {
-		req.Query.Add("includeEpisodeImages", fmt.Sprint(*filter.IncludeEpisodeImages))
 	}
 
 	if err := s.GetInto(ctx, req, &output); err != nil {

--- a/sonarr/calendar.go
+++ b/sonarr/calendar.go
@@ -13,35 +13,32 @@ import (
 // Define Base Path for Calendar queries.
 const bpCalendar = APIver + "/calendar"
 
-// CalendarTimeFilterFormat is the Go  time format the calendar expects the filter to be in.
-const CalendarTimeFilterFormat = "2006-01-02T03:04:05.000Z"
-
 // Calendar represents the data that may be returned from the calendar endpoint.
 type Calendar struct {
-	ID                         int64          `json:"id"`
-	SeriesID                   int64          `json:"seriesId"`
-	TvdbID                     int64          `json:"tvdbId"`
-	EpisodeFileID              int64          `json:"episodeFileId"`
-	SeasonNumber               int            `json:"seasonNumber"`
-	EpisodeNumber              int            `json:"episodeNumber"`
-	Title                      string         `json:"title"`
+	AbsoluteEpisodeNumber      int            `json:"absoluteEpisodeNumber"`
 	AirDate                    string         `json:"airDate"`
 	AirDateUtc                 time.Time      `json:"airDateUtc"`
-	Overview                   string         `json:"overview"`
+	EndTime                    time.Time      `json:"endTime"`
 	EpisodeFile                *EpisodeFile   `json:"episodeFile"`
+	EpisodeFileID              int64          `json:"episodeFileId"`
+	EpisodeNumber              int            `json:"episodeNumber"`
+	GrabDate                   time.Time      `json:"grabDate"`
+	Grabbed                    bool           `json:"grabbed"`
 	HasFile                    bool           `json:"hasFile"`
+	ID                         int64          `json:"id"`
+	Images                     []*starr.Image `json:"images,omitempty"`
 	Monitored                  bool           `json:"monitored"`
-	AbsoluteEpisodeNumber      int            `json:"absoluteEpisodeNumber"`
+	Overview                   string         `json:"overview"`
 	SceneAbsoluteEpisodeNumber int            `json:"sceneAbsoluteEpisodeNumber"`
 	SceneEpisodeNumber         int            `json:"sceneEpisodeNumber"`
 	SceneSeasonNumber          int            `json:"sceneSeasonNumber"`
-	UnverifiedSceneNumbering   bool           `json:"unverifiedSceneNumbering"`
-	EndTime                    time.Time      `json:"endTime"`
-	GrabDate                   time.Time      `json:"grabDate"`
-	SeriesTitle                string         `json:"seriesTitle"`
+	SeasonNumber               int            `json:"seasonNumber"`
 	Series                     *Series        `json:"series"`
-	Images                     []*starr.Image `json:"images,omitempty"`
-	Grabbed                    bool           `json:"grabbed"`
+	SeriesID                   int64          `json:"seriesId"`
+	SeriesTitle                string         `json:"seriesTitle"`
+	Title                      string         `json:"title"`
+	TvdbID                     int64          `json:"tvdbId"`
+	UnverifiedSceneNumbering   bool           `json:"unverifiedSceneNumbering"`
 }
 
 // CalendarInput defines the filters for fetching calendar items.
@@ -67,11 +64,11 @@ func (s *Sonarr) GetCalendarContext(ctx context.Context, filter CalendarInput) (
 	req := starr.Request{URI: bpCalendar, Query: make(url.Values)}
 
 	if !filter.Start.IsZero() {
-		req.Query.Add("start", filter.Start.UTC().Format(CalendarTimeFilterFormat))
+		req.Query.Add("start", filter.Start.UTC().Format(starr.CalendarTimeFilterFormat))
 	}
 
 	if !filter.End.IsZero() {
-		req.Query.Add("end", filter.End.UTC().Format(CalendarTimeFilterFormat))
+		req.Query.Add("end", filter.End.UTC().Format(starr.CalendarTimeFilterFormat))
 	}
 
 	if filter.Unmonitored != nil {

--- a/sonarr/calendar.go
+++ b/sonarr/calendar.go
@@ -1,0 +1,115 @@
+package sonarr
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+	"time"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for Calendar queries.
+const bpCalendar = APIver + "/calendar"
+
+// CalendarTimeFilterFormat is the Go  time format the calendar expects the filter to be in.
+const CalendarTimeFilterFormat = "2006-01-02T03:04:05.000Z"
+
+// Calendar represents the data that may be returned from the calendar endpoint.
+type Calendar struct {
+	ID                         int64          `json:"id"`
+	SeriesID                   int64          `json:"seriesId"`
+	TvdbID                     int64          `json:"tvdbId"`
+	EpisodeFileID              int64          `json:"episodeFileId"`
+	SeasonNumber               int            `json:"seasonNumber"`
+	EpisodeNumber              int            `json:"episodeNumber"`
+	Title                      string         `json:"title"`
+	AirDate                    string         `json:"airDate"`
+	AirDateUtc                 time.Time      `json:"airDateUtc"`
+	Overview                   string         `json:"overview"`
+	EpisodeFile                *EpisodeFile   `json:"episodeFile"`
+	HasFile                    bool           `json:"hasFile"`
+	Monitored                  bool           `json:"monitored"`
+	AbsoluteEpisodeNumber      int            `json:"absoluteEpisodeNumber"`
+	SceneAbsoluteEpisodeNumber int            `json:"sceneAbsoluteEpisodeNumber"`
+	SceneEpisodeNumber         int            `json:"sceneEpisodeNumber"`
+	SceneSeasonNumber          int            `json:"sceneSeasonNumber"`
+	UnverifiedSceneNumbering   bool           `json:"unverifiedSceneNumbering"`
+	EndTime                    time.Time      `json:"endTime"`
+	GrabDate                   time.Time      `json:"grabDate"`
+	SeriesTitle                string         `json:"seriesTitle"`
+	Series                     *Series        `json:"series"`
+	Images                     []*starr.Image `json:"images,omitempty"`
+	Grabbed                    bool           `json:"grabbed"`
+}
+
+// CalendarInput defines the filters for fetching calendar items.
+// Start and End are required. Use starr.True() and starr.False() to fill in the booleans.
+type CalendarInput struct {
+	Start                time.Time
+	End                  time.Time
+	Unmonitored          *bool
+	IncludeSeries        *bool
+	IncludeEpisodeFile   *bool
+	IncludeEpisodeImages *bool
+}
+
+// GetCalendar returns calendars based on filters.
+func (s *Sonarr) GetCalendar(filter CalendarInput) ([]*Calendar, error) {
+	return s.GetCalendarContext(context.Background(), filter)
+}
+
+// GetCalendarContext returns calendars based on filters.
+func (s *Sonarr) GetCalendarContext(ctx context.Context, filter CalendarInput) ([]*Calendar, error) {
+	var output []*Calendar
+
+	req := starr.Request{URI: bpCalendar, Query: make(url.Values)}
+
+	if !filter.Start.IsZero() {
+		req.Query.Add("start", filter.Start.UTC().Format(CalendarTimeFilterFormat))
+	}
+
+	if !filter.End.IsZero() {
+		req.Query.Add("end", filter.End.UTC().Format(CalendarTimeFilterFormat))
+	}
+
+	if filter.Unmonitored != nil {
+		req.Query.Add("unmonitored", fmt.Sprint(*filter.Unmonitored))
+	}
+
+	if filter.IncludeSeries != nil {
+		req.Query.Add("includeSeries", fmt.Sprint(*filter.IncludeSeries))
+	}
+
+	if filter.IncludeEpisodeFile != nil {
+		req.Query.Add("includeEpisodeFile", fmt.Sprint(*filter.IncludeEpisodeFile))
+	}
+
+	if filter.IncludeEpisodeImages != nil {
+		req.Query.Add("includeEpisodeImages", fmt.Sprint(*filter.IncludeEpisodeImages))
+	}
+
+	if err := s.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetCalendarID returns a single calendar by ID.
+func (s *Sonarr) GetCalendarID(calendarID int64) (*Calendar, error) {
+	return s.GetCalendarIDContext(context.Background(), calendarID)
+}
+
+// GetCalendarIDContext returns a single calendar by ID.
+func (s *Sonarr) GetCalendarIDContext(ctx context.Context, calendarID int64) (*Calendar, error) {
+	var output *Calendar
+
+	req := starr.Request{URI: path.Join(bpCalendar, fmt.Sprint(calendarID))}
+	if err := s.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}

--- a/sonarr/calendar_test.go
+++ b/sonarr/calendar_test.go
@@ -1,0 +1,238 @@
+package sonarr_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/sonarr"
+)
+
+var testCalendarJSON = `{
+	"seriesId": 1,
+	"tvdbId": 8484175,
+	"episodeFileId": 0,
+	"seasonNumber": 0,
+	"episodeNumber": 1,
+	"title": "Dead Zone",
+	"airDate": "1989-07-15",
+	"airDateUtc": "1989-07-14T15:00:00Z",
+	"overview": "...",
+	"hasFile": false,
+	"monitored": false,
+	"unverifiedSceneNumbering": false,
+	"series": {
+	  "title": "Dragon Ball Z",
+	  "sortTitle": "dragon ball z",
+	  "status": "ended",
+	  "ended": true,
+	  "overview": "...",
+	  "network": "Fuji TV",
+	  "images": [
+		{
+		  "coverType": "fanart",
+		  "url": "https://artworks.thetvdb.com/banners/fanart/original/81472-26.jpg"
+		}
+	  ],
+	  "seasons": [
+		{
+		  "seasonNumber": 0,
+		  "monitored": false
+		}
+	  ],
+	  "year": 1989,
+	  "path": "/tv/[DBNL] Dragon Ball Z Digitally Remastered",
+	  "qualityProfileId": 1,
+	  "languageProfileId": 1,
+	  "seasonFolder": true,
+	  "monitored": false,
+	  "useSceneNumbering": true,
+	  "runtime": 25,
+	  "tvdbId": 81472,
+	  "tvRageId": 3373,
+	  "tvMazeId": 2103,
+	  "firstAired": "1989-04-26T00:00:00Z",
+	  "seriesType": "standard",
+	  "cleanTitle": "dragonballz",
+	  "imdbId": "tt0214341",
+	  "titleSlug": "dragon-ball-z",
+	  "certification": "TV-PG",
+	  "genres": [
+		"Action",
+		"Adventure",
+		"Animation",
+		"Anime",
+		"Fantasy",
+		"Science Fiction",
+		"Thriller"
+	  ],
+	  "tags": [],
+	  "added": "2018-04-19T08:46:03.367045Z",
+	  "ratings": {
+		"votes": 4659,
+		"value": 8.7
+	  },
+	  "id": 1
+	},
+	"images": [],
+	"id": 1
+  }
+  `
+
+// This matches the json above.
+var testCalendarStruct = sonarr.Calendar{
+	ID:                       1,
+	SeriesID:                 1,
+	TvdbID:                   8484175,
+	EpisodeFileID:            0,
+	SeasonNumber:             0,
+	EpisodeNumber:            1,
+	Title:                    "Dead Zone",
+	AirDate:                  "1989-07-15",
+	AirDateUtc:               time.Date(1989, 7, 14, 15, 0, 0, 0, time.UTC),
+	Overview:                 "...",
+	EpisodeFile:              nil, // this isn't checked...
+	HasFile:                  false,
+	Monitored:                false,
+	UnverifiedSceneNumbering: false,
+	Series: &sonarr.Series{
+		Ended:             true,
+		Monitored:         false,
+		SeasonFolder:      true,
+		UseSceneNumbering: true,
+		Runtime:           25,
+		Year:              1989,
+		ID:                1,
+		LanguageProfileID: 1,
+		QualityProfileID:  1,
+		TvdbID:            81472,
+		TvMazeID:          2103,
+		TvRageID:          3373,
+		AirTime:           "",
+		Certification:     "TV-PG",
+		CleanTitle:        "dragonballz",
+		ImdbID:            "tt0214341",
+		Network:           "Fuji TV",
+		Overview:          "...",
+		Path:              "/tv/[DBNL] Dragon Ball Z Digitally Remastered",
+		SeriesType:        "standard",
+		SortTitle:         "dragon ball z",
+		Status:            "ended",
+		Title:             "Dragon Ball Z",
+		TitleSlug:         "dragon-ball-z",
+		Added:             time.Date(2018, 4, 19, 8, 46, 3, 367045000, time.UTC),
+		FirstAired:        time.Date(1989, 4, 26, 0, 0, 0, 0, time.UTC),
+		Ratings: &starr.Ratings{
+			Votes: 4659,
+			Value: 8.7,
+		},
+		Tags:            []int{},
+		Genres:          []string{"Action", "Adventure", "Animation", "Anime", "Fantasy", "Science Fiction", "Thriller"},
+		AlternateTitles: []*sonarr.AlternateTitle(nil),
+		Seasons:         []*sonarr.Season{{SeasonNumber: 0, Monitored: false}},
+		Images: []*starr.Image{
+			{CoverType: "fanart", URL: "https://artworks.thetvdb.com/banners/fanart/original/81472-26.jpg"},
+		},
+	},
+	Images: []*starr.Image{},
+}
+
+func TestGetCalendar(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name: "200",
+			ExpectedPath: "/api/v3/calendar" +
+				"?end=2020-02-20T04%3A20%3A20.000Z" +
+				"&includeEpisodeFile=false" +
+				"&includeEpisodeImages=false" +
+				"&includeSeries=true" +
+				"&start=2020-02-20T04%3A20%3A20.000Z" +
+				"&unmonitored=true",
+			ResponseStatus: http.StatusOK,
+			ResponseBody:   `[` + testCalendarJSON + `]`,
+			WithRequest: sonarr.CalendarInput{
+				Start:                time.Unix(1582172420, 0),
+				End:                  time.Unix(1582172420, 0),
+				Unmonitored:          starr.True(),
+				IncludeSeries:        starr.True(),
+				IncludeEpisodeFile:   starr.False(),
+				IncludeEpisodeImages: starr.False(),
+			},
+			WithError:      nil,
+			ExpectedMethod: http.MethodGet,
+			WithResponse:   []*sonarr.Calendar{&testCalendarStruct},
+		},
+		{
+			Name: "404",
+			ExpectedPath: "/api/v3/calendar" +
+				"?end=2020-02-20T04%3A20%3A20.000Z" +
+				"&start=2020-02-20T04%3A20%3A20.000Z" +
+				"&unmonitored=true",
+			ResponseStatus: http.StatusNotFound,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			ExpectedMethod: http.MethodGet,
+			WithRequest: sonarr.CalendarInput{
+				Start:       time.Unix(1582172420, 0),
+				End:         time.Unix(1582172420, 0),
+				Unmonitored: starr.True(),
+			},
+			WithResponse: []*sonarr.Calendar(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetCalendar(test.WithRequest.(sonarr.CalendarInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetCalendarID(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   "/api/v3/calendar/1",
+			ResponseStatus: http.StatusOK,
+			ResponseBody:   testCalendarJSON,
+			WithRequest:    int64(1),
+			WithError:      nil,
+			ExpectedMethod: http.MethodGet,
+			WithResponse:   &testCalendarStruct,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   "/api/v3/calendar/1",
+			ResponseStatus: http.StatusNotFound,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			ExpectedMethod: http.MethodGet,
+			WithRequest:    int64(1),
+			WithResponse:   (*sonarr.Calendar)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetCalendarID(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}

--- a/sonarr/calendar_test.go
+++ b/sonarr/calendar_test.go
@@ -82,7 +82,7 @@ var testCalendarJSON = `{
   `
 
 // This matches the json above.
-var testCalendarStruct = sonarr.Calendar{
+var testCalendarStruct = sonarr.Episode{
 	ID:                       1,
 	SeriesID:                 1,
 	TvdbID:                   8484175,
@@ -93,7 +93,6 @@ var testCalendarStruct = sonarr.Calendar{
 	AirDate:                  "1989-07-15",
 	AirDateUtc:               time.Date(1989, 7, 14, 15, 0, 0, 0, time.UTC),
 	Overview:                 "...",
-	EpisodeFile:              nil, // this isn't checked...
 	HasFile:                  false,
 	Monitored:                false,
 	UnverifiedSceneNumbering: false,
@@ -154,7 +153,7 @@ func TestGetCalendar(t *testing.T) {
 				"&unmonitored=true",
 			ResponseStatus: http.StatusOK,
 			ResponseBody:   `[` + testCalendarJSON + `]`,
-			WithRequest: sonarr.CalendarInput{
+			WithRequest: sonarr.Calendar{
 				Start:                time.Unix(1582172420, 0),
 				End:                  time.Unix(1582172420, 0),
 				Unmonitored:          starr.True(),
@@ -164,7 +163,7 @@ func TestGetCalendar(t *testing.T) {
 			},
 			WithError:      nil,
 			ExpectedMethod: http.MethodGet,
-			WithResponse:   []*sonarr.Calendar{&testCalendarStruct},
+			WithResponse:   []*sonarr.Episode{&testCalendarStruct},
 		},
 		{
 			Name: "404",
@@ -176,12 +175,12 @@ func TestGetCalendar(t *testing.T) {
 			ResponseBody:   `{"message": "NotFound"}`,
 			WithError:      starr.ErrInvalidStatusCode,
 			ExpectedMethod: http.MethodGet,
-			WithRequest: sonarr.CalendarInput{
+			WithRequest: sonarr.Calendar{
 				Start:       time.Unix(1582172420, 0),
 				End:         time.Unix(1582172420, 0),
 				Unmonitored: starr.True(),
 			},
-			WithResponse: []*sonarr.Calendar(nil),
+			WithResponse: []*sonarr.Episode(nil),
 		},
 	}
 
@@ -191,7 +190,7 @@ func TestGetCalendar(t *testing.T) {
 			t.Parallel()
 			mockServer := test.GetMockServer(t)
 			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
-			output, err := client.GetCalendar(test.WithRequest.(sonarr.CalendarInput))
+			output, err := client.GetCalendar(test.WithRequest.(sonarr.Calendar))
 			assert.ErrorIs(t, err, test.WithError, "the wrong error was returned")
 			assert.EqualValues(t, test.WithResponse, output, "make sure ResponseBody and WithResponse are a match")
 		})
@@ -220,7 +219,7 @@ func TestGetCalendarID(t *testing.T) {
 			WithError:      starr.ErrInvalidStatusCode,
 			ExpectedMethod: http.MethodGet,
 			WithRequest:    int64(1),
-			WithResponse:   (*sonarr.Calendar)(nil),
+			WithResponse:   (*sonarr.Episode)(nil),
 		},
 	}
 

--- a/sonarr/calendar_test.go
+++ b/sonarr/calendar_test.go
@@ -192,8 +192,8 @@ func TestGetCalendar(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.GetCalendar(test.WithRequest.(sonarr.CalendarInput))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
-			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+			assert.ErrorIs(t, err, test.WithError, "the wrong error was returned")
+			assert.EqualValues(t, test.WithResponse, output, "make sure ResponseBody and WithResponse are a match")
 		})
 	}
 }
@@ -231,8 +231,8 @@ func TestGetCalendarID(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.GetCalendarID(test.WithRequest.(int64))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
-			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+			assert.ErrorIs(t, err, test.WithError, "the wrong error was returned")
+			assert.EqualValues(t, test.WithResponse, output, "make sure ResponseBody and WithResponse are a match")
 		})
 	}
 }

--- a/sonarr/calendar_test.go
+++ b/sonarr/calendar_test.go
@@ -156,10 +156,10 @@ func TestGetCalendar(t *testing.T) {
 			WithRequest: sonarr.Calendar{
 				Start:                time.Unix(1582172420, 0),
 				End:                  time.Unix(1582172420, 0),
-				Unmonitored:          starr.True(),
-				IncludeSeries:        starr.True(),
-				IncludeEpisodeFile:   starr.False(),
-				IncludeEpisodeImages: starr.False(),
+				Unmonitored:          true,
+				IncludeSeries:        true,
+				IncludeEpisodeFile:   false,
+				IncludeEpisodeImages: false,
 			},
 			WithError:      nil,
 			ExpectedMethod: http.MethodGet,
@@ -169,6 +169,9 @@ func TestGetCalendar(t *testing.T) {
 			Name: "404",
 			ExpectedPath: "/api/v3/calendar" +
 				"?end=2020-02-20T04%3A20%3A20.000Z" +
+				"&includeEpisodeFile=false" +
+				"&includeEpisodeImages=false" +
+				"&includeSeries=false" +
 				"&start=2020-02-20T04%3A20%3A20.000Z" +
 				"&unmonitored=true",
 			ResponseStatus: http.StatusNotFound,
@@ -178,7 +181,7 @@ func TestGetCalendar(t *testing.T) {
 			WithRequest: sonarr.Calendar{
 				Start:       time.Unix(1582172420, 0),
 				End:         time.Unix(1582172420, 0),
-				Unmonitored: starr.True(),
+				Unmonitored: true,
 			},
 			WithResponse: []*sonarr.Episode(nil),
 		},

--- a/sonarr/episode.go
+++ b/sonarr/episode.go
@@ -16,19 +16,22 @@ const bpEpisode = APIver + "/episode"
 
 // Episode is the /api/v3/episode endpoint.
 type Episode struct {
-	ID                       int64     `json:"id"`
-	SeriesID                 int64     `json:"seriesId"`
-	AbsoluteEpisodeNumber    int64     `json:"absoluteEpisodeNumber"`
-	EpisodeFileID            int64     `json:"episodeFileId"`
-	SeasonNumber             int64     `json:"seasonNumber"`
-	EpisodeNumber            int64     `json:"episodeNumber"`
-	AirDateUtc               time.Time `json:"airDateUtc"`
-	AirDate                  string    `json:"airDate"`
-	Title                    string    `json:"title"`
-	Overview                 string    `json:"overview"`
-	UnverifiedSceneNumbering bool      `json:"unverifiedSceneNumbering"`
-	HasFile                  bool      `json:"hasFile"`
-	Monitored                bool      `json:"monitored"`
+	ID                       int64          `json:"id"`
+	SeriesID                 int64          `json:"seriesId"`
+	TvdbID                   int64          `json:"tvdbId"`
+	AbsoluteEpisodeNumber    int64          `json:"absoluteEpisodeNumber"`
+	EpisodeFileID            int64          `json:"episodeFileId"`
+	SeasonNumber             int64          `json:"seasonNumber"`
+	EpisodeNumber            int64          `json:"episodeNumber"`
+	AirDateUtc               time.Time      `json:"airDateUtc"`
+	AirDate                  string         `json:"airDate"`
+	Title                    string         `json:"title"`
+	Overview                 string         `json:"overview"`
+	UnverifiedSceneNumbering bool           `json:"unverifiedSceneNumbering"`
+	HasFile                  bool           `json:"hasFile"`
+	Monitored                bool           `json:"monitored"`
+	Images                   []*starr.Image `json:"images"`
+	Series                   *Series        `json:"series"`
 }
 
 // GetSeriesEpisodes returns all episodes for a series by series ID.

--- a/sonarr/episodefile.go
+++ b/sonarr/episodefile.go
@@ -16,20 +16,21 @@ const bpEpisodeFile = APIver + "/episodeFile"
 
 // EpisodeFile is the output from the /api/v3/episodeFile endpoint.
 type EpisodeFile struct {
-	ID                   int64          `json:"id"`
-	SeriesID             int64          `json:"seriesId"`
-	SeasonNumber         int            `json:"seasonNumber"`
-	RelativePath         string         `json:"relativePath"`
-	Path                 string         `json:"path"`
-	Size                 int64          `json:"size"`
-	DateAdded            time.Time      `json:"dateAdded"`
-	SceneName            string         `json:"sceneName"`
-	ReleaseGroup         string         `json:"releaseGroup"`
-	Language             *starr.Value   `json:"language"`
-	Quality              *starr.Quality `json:"quality"`
-	MediaInfo            *MediaInfo     `json:"mediaInfo"`
-	QualityCutoffNotMet  bool           `json:"qualityCutoffNotMet"`
-	LanguageCutoffNotMet bool           `json:"languageCutoffNotMet"`
+	ID                   int64           `json:"id"`
+	SeriesID             int64           `json:"seriesId"`
+	SeasonNumber         int             `json:"seasonNumber"`
+	RelativePath         string          `json:"relativePath"`
+	Path                 string          `json:"path"`
+	Size                 int64           `json:"size"`
+	DateAdded            time.Time       `json:"dateAdded"`
+	SceneName            string          `json:"sceneName"`
+	ReleaseGroup         string          `json:"releaseGroup"`
+	Language             *starr.Value    `json:"language"`
+	Quality              *starr.Quality  `json:"quality"`
+	MediaInfo            *MediaInfo      `json:"mediaInfo"`
+	QualityCutoffNotMet  bool            `json:"qualityCutoffNotMet"`
+	LanguageCutoffNotMet bool            `json:"languageCutoffNotMet"`
+	CustomFormats        []*CustomFormat `json:"customFormats"` // v4 only
 }
 
 // MediaInfo is part of an EpisodeFile.


### PR DESCRIPTION
Closes half of #66. I'm only going to do Sonarr and Readarr in this 1 PR to keep it smaller. Will make another one for the other two apps.

- [x] Sonarr
- [x] Readarr

Cleans up `Book`, `Author`, and `Episode` types. Probably easier to look at without white-space changes: https://github.com/golift/starr/pull/71/files?w=1