### PR TITLE
Add config/naming to Radarr

### DIFF
--- a/radarr/naming.go
+++ b/radarr/naming.go
@@ -20,8 +20,8 @@ type Naming struct {
 	ReplaceSpaces            bool   `json:"replaceSpaces,omitempty"`
 	ID                       int64  `json:"id"` // ID must always be 1 (Oct 10, 2022)
 	ColonReplacementFormat   string `json:"colonReplacementFormat,omitempty"`
-	StandardMovieFormat      string `json:"standardMovieFormat,omitempty"`
-	MovieFolderFormat        string `json:"movieFolderFormat,omitempty"`
+	StandardMovieFormat      string `json:"standardMovieFormat"` // required
+	MovieFolderFormat        string `json:"movieFolderFormat"`   // required
 	Separator                string `json:"separatort,omitempty"`
 	NumberStyle              string `json:"numberStylet,omitempty"`
 }

--- a/radarr/naming.go
+++ b/radarr/naming.go
@@ -1,0 +1,66 @@
+package radarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for Naming calls.
+const bpNaming = APIver + "/config/naming"
+
+// Naming represents the config/naming endpoint in Radarr.
+type Naming struct {
+	RenameMovies             bool   `json:"renameMovies,omitempty"`
+	ReplaceIllegalCharacters bool   `json:"replaceIllegalCharacters,omitempty"`
+	IncludeQuality           bool   `json:"includeQuality,omitempty"`
+	ReplaceSpaces            bool   `json:"replaceSpaces,omitempty"`
+	ID                       int64  `json:"id"` // ID must always be 1 (Oct 10, 2022)
+	ColonReplacementFormat   string `json:"colonReplacementFormat,omitempty"`
+	StandardMovieFormat      string `json:"standardMovieFormat,omitempty"`
+	MovieFolderFormat        string `json:"movieFolderFormat,omitempty"`
+	Separator                string `json:"separatort,omitempty"`
+	NumberStyle              string `json:"numberStylet,omitempty"`
+}
+
+// GetNaming returns the file naming rules.
+func (r *Radarr) GetNaming() (*Naming, error) {
+	return r.GetNamingContext(context.Background())
+}
+
+// GetNamingContext returns the file naming rules.
+func (r *Radarr) GetNamingContext(ctx context.Context) (*Naming, error) {
+	var output Naming
+
+	req := starr.Request{URI: bpNaming}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateNaming updates the file naming rules.
+func (r *Radarr) UpdateNaming(naming *Naming) (*Naming, error) {
+	return r.UpdateNamingContext(context.Background(), naming)
+}
+
+// UpdateNamingContext updates the file naming rules.
+func (r *Radarr) UpdateNamingContext(ctx context.Context, naming *Naming) (*Naming, error) {
+	var output Naming
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(naming); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpNaming, err)
+	}
+
+	req := starr.Request{URI: bpNaming, Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}

--- a/radarr/naming_test.go
+++ b/radarr/naming_test.go
@@ -1,0 +1,123 @@
+package radarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+)
+
+const namingBody = `{
+	"renameMovies": true,
+	"replaceIllegalCharacters": true,
+	"colonReplacementFormat": "delete",
+	"standardMovieFormat": "{Movie.Title}.{Release.Year}.{Quality.Title}",
+	"movieFolderFormat": "{Movie Title} ({Release Year})",
+	"includeQuality": true,
+	"replaceSpaces": true,
+	"id": 1
+  }`
+
+func TestGetNaming(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "config", "naming"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   namingBody,
+			WithResponse: &radarr.Naming{
+				ID:                       1,
+				ReplaceIllegalCharacters: true,
+				IncludeQuality:           true,
+				ReplaceSpaces:            true,
+				RenameMovies:             true,
+				ColonReplacementFormat:   "delete",
+				StandardMovieFormat:      "{Movie.Title}.{Release.Year}.{Quality.Title}",
+				MovieFolderFormat:        "{Movie Title} ({Release Year})",
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "config", "naming"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*radarr.Naming)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetNaming()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateNaming(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "202",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "config", "naming"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 202,
+			WithRequest: &radarr.Naming{
+				ID:                       1,
+				ReplaceIllegalCharacters: true,
+			},
+			ExpectedRequest: `{"replaceIllegalCharacters":true,"id":1}` + "\n",
+			ResponseBody:    namingBody,
+			WithResponse: &radarr.Naming{
+				ID:                       1,
+				ReplaceIllegalCharacters: true,
+				IncludeQuality:           true,
+				ReplaceSpaces:            true,
+				RenameMovies:             true,
+				ColonReplacementFormat:   "delete",
+				StandardMovieFormat:      "{Movie.Title}.{Release.Year}.{Quality.Title}",
+				MovieFolderFormat:        "{Movie Title} ({Release Year})",
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "config", "naming"),
+			ExpectedMethod: "PUT",
+			WithRequest: &radarr.Naming{
+				ID:                       1,
+				ReplaceIllegalCharacters: true,
+			},
+			ExpectedRequest: `{"replaceIllegalCharacters":true,"id":1}` + "\n",
+			ResponseStatus:  404,
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.Naming)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateNaming(test.WithRequest.(*radarr.Naming))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "test.WithResponse does not match the actual response")
+		})
+	}
+}

--- a/sonarr/naming.go
+++ b/sonarr/naming.go
@@ -12,6 +12,7 @@ import (
 // Define Base Path for Naming calls.
 const bpNaming = APIver + "/config/naming"
 
+// Naming represents the config/naming endpoint in Sonarr.
 type Naming struct {
 	RenameEpisodes           bool   `json:"renameEpisodes,omitempty"`
 	ReplaceIllegalCharacters bool   `json:"replaceIllegalCharacters,omitempty"`

--- a/sonarr/naming_test.go
+++ b/sonarr/naming_test.go
@@ -139,7 +139,7 @@ func TestUpdateNaming(t *testing.T) {
 			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.UpdateNaming(test.WithRequest.(*sonarr.Naming))
 			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
-			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
 	}
 }

--- a/test_methods.go
+++ b/test_methods.go
@@ -33,6 +33,8 @@ const (
 )
 
 // GetMockServer is used in all the http tests.
+//
+//nolint:lll
 func (test *TestMockData) GetMockServer(t *testing.T) *httptest.Server {
 	t.Helper()
 

--- a/test_methods.go
+++ b/test_methods.go
@@ -37,14 +37,14 @@ func (test *TestMockData) GetMockServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
 	return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
-		assert.EqualValues(t, test.ExpectedPath, req.URL.String())
+		assert.EqualValues(t, test.ExpectedPath, req.URL.String(), "test.ExpectedPath does not match the actual path")
 		writer.WriteHeader(test.ResponseStatus)
 
-		assert.EqualValues(t, test.ExpectedMethod, req.Method)
+		assert.EqualValues(t, test.ExpectedMethod, req.Method, "test.ExpectedMethod does not match the actual method")
 
 		body, err := io.ReadAll(req.Body)
 		assert.NoError(t, err)
-		assert.EqualValues(t, test.ExpectedRequest, string(body))
+		assert.EqualValues(t, test.ExpectedRequest, string(body), "test.ExpectedRequest does not match body for actual request")
 
 		_, err = writer.Write([]byte(test.ResponseBody))
 		assert.NoError(t, err)


### PR DESCRIPTION
Adds `config/naming` endpoints to Radarr. Pretty much copy/paste from Sonarr. 