### PR TITLE
feature(radarr): delay profile

### DIFF
--- a/radarr/delayprofile.go
+++ b/radarr/delayprofile.go
@@ -1,0 +1,120 @@
+package radarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for Delay Profile calls.
+const bpDelayProfile = APIver + "/delayProfile"
+
+// DelayProfile is the /api/v3/delayprofile endpoint.
+type DelayProfile struct {
+	EnableUsenet           bool   `json:"enableUsenet,omitempty"`
+	EnableTorrent          bool   `json:"enableTorrent,omitempty"`
+	BypassIfHighestQuality bool   `json:"bypassIfHighestQuality,omitempty"`
+	UsenetDelay            int64  `json:"usenetDelay,omitempty"`
+	TorrentDelay           int64  `json:"torrentDelay,omitempty"`
+	ID                     int64  `json:"id,omitempty"`
+	Order                  int64  `json:"order,omitempty"`
+	Tags                   []int  `json:"tags"`
+	PreferredProtocol      string `json:"preferredProtocol,omitempty"`
+}
+
+// GetDelayProfiles returns all configured delay profiles.
+func (r *Radarr) GetDelayProfiles() ([]*DelayProfile, error) {
+	return r.GetDelayProfilesContext(context.Background())
+}
+
+// GetDelayProfilesContext returns all configured delay profiles.
+func (r *Radarr) GetDelayProfilesContext(ctx context.Context) ([]*DelayProfile, error) {
+	var output []*DelayProfile
+
+	req := starr.Request{URI: bpDelayProfile}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetDelayProfile returns a single delay profile.
+func (r *Radarr) GetDelayProfile(profileID int64) (*DelayProfile, error) {
+	return r.GetDelayProfileContext(context.Background(), profileID)
+}
+
+// GetDelayProfileContext returns a single delay profile.
+func (r *Radarr) GetDelayProfileContext(ctx context.Context, profileID int64) (*DelayProfile, error) {
+	var output DelayProfile
+
+	req := starr.Request{URI: path.Join(bpDelayProfile, fmt.Sprint(profileID))}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// AddDelayProfile creates a delay profile.
+func (r *Radarr) AddDelayProfile(profile *DelayProfile) (*DelayProfile, error) {
+	return r.AddDelayProfileContext(context.Background(), profile)
+}
+
+// AddDelayProfileContext creates a delay profile.
+func (r *Radarr) AddDelayProfileContext(ctx context.Context, profile *DelayProfile) (*DelayProfile, error) {
+	var output DelayProfile
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDelayProfile, err)
+	}
+
+	req := starr.Request{URI: bpDelayProfile, Body: &body}
+	if err := r.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateDelayProfile updates the delay profile.
+func (r *Radarr) UpdateDelayProfile(profile *DelayProfile) (*DelayProfile, error) {
+	return r.UpdateDelayProfileContext(context.Background(), profile)
+}
+
+// UpdateDelayProfileContext updates the delay profile.
+func (r *Radarr) UpdateDelayProfileContext(ctx context.Context, profile *DelayProfile) (*DelayProfile, error) {
+	var output DelayProfile
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(profile); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDelayProfile, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpDelayProfile, fmt.Sprint(profile.ID)), Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// DeleteDelayProfile removes a single delay profile.
+func (r *Radarr) DeleteDelayProfile(profileID int64) error {
+	return r.DeleteDelayProfileContext(context.Background(), profileID)
+}
+
+// DeleteDelayProfileContext removes a single delay profile.
+func (r *Radarr) DeleteDelayProfileContext(ctx context.Context, profileID int64) error {
+	req := starr.Request{URI: path.Join(bpDelayProfile, fmt.Sprint(profileID))}
+	if err := r.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/radarr/delayprofile.go
+++ b/radarr/delayprofile.go
@@ -61,6 +61,8 @@ func (r *Radarr) GetDelayProfileContext(ctx context.Context, profileID int64) (*
 }
 
 // AddDelayProfile creates a delay profile.
+// AddDelayProfile doesn't take into account the "order" field sent on creation.
+// Order will be set to first available. This can only be edited via UpdateDelayProfile later on.
 func (r *Radarr) AddDelayProfile(profile *DelayProfile) (*DelayProfile, error) {
 	return r.AddDelayProfileContext(context.Background(), profile)
 }

--- a/radarr/delayprofile_test.go
+++ b/radarr/delayprofile_test.go
@@ -1,0 +1,310 @@
+package radarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+)
+
+const (
+	firstDelayProfile = `{
+		"enableUsenet": true,
+		"enableTorrent": true,
+		"preferredProtocol": "usenet",
+		"usenetDelay": 0,
+		"torrentDelay": 0,
+		"bypassIfHighestQuality": true,
+		"order": 2147483647,
+		"tags": [],
+		"id": 1
+	}`
+	secondDelayProfile = `{
+		"enableUsenet": false,
+		"enableTorrent": true,
+		"preferredProtocol": "torrent",
+		"usenetDelay": 0,
+		"torrentDelay": 0,
+		"bypassIfHighestQuality": false,
+		"order": 1,
+		"tags": [11],
+		"id": 10
+	}`
+	delayProfileRequest = `{"enableTorrent":true,"order":1,"tags":[11],"preferredProtocol":"torrent"}` + "\n"
+)
+
+func TestGetDelayProfiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "delayProfile"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   `[` + firstDelayProfile + `,` + secondDelayProfile + `]`,
+			WithResponse: []*radarr.DelayProfile{
+				{
+					EnableUsenet:           true,
+					EnableTorrent:          true,
+					PreferredProtocol:      "usenet",
+					UsenetDelay:            0,
+					TorrentDelay:           0,
+					BypassIfHighestQuality: true,
+					Order:                  2147483647,
+					Tags:                   []int{},
+					ID:                     1,
+				},
+				{
+					EnableUsenet:           false,
+					EnableTorrent:          true,
+					PreferredProtocol:      "torrent",
+					UsenetDelay:            0,
+					TorrentDelay:           0,
+					BypassIfHighestQuality: false,
+					Order:                  1,
+					Tags:                   []int{11},
+					ID:                     10,
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "delayProfile"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   []*radarr.DelayProfile(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDelayProfiles()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetDelayProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "delayProfile/1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			WithRequest:    int64(1),
+			ResponseBody:   firstDelayProfile,
+			WithResponse: &radarr.DelayProfile{
+				EnableUsenet:           true,
+				EnableTorrent:          true,
+				PreferredProtocol:      "usenet",
+				UsenetDelay:            0,
+				TorrentDelay:           0,
+				BypassIfHighestQuality: true,
+				Order:                  2147483647,
+				Tags:                   []int{},
+				ID:                     1,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "delayProfile", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			WithRequest:    int64(1),
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*radarr.DelayProfile)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDelayProfile(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddDelayProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "delayProfile"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 200,
+			WithRequest: &radarr.DelayProfile{
+				EnableUsenet:           false,
+				EnableTorrent:          true,
+				PreferredProtocol:      "torrent",
+				UsenetDelay:            0,
+				TorrentDelay:           0,
+				BypassIfHighestQuality: false,
+				Order:                  1,
+				Tags:                   []int{11},
+			},
+			ExpectedRequest: delayProfileRequest,
+			ResponseBody:    secondDelayProfile,
+			WithResponse: &radarr.DelayProfile{
+				EnableUsenet:           false,
+				EnableTorrent:          true,
+				PreferredProtocol:      "torrent",
+				UsenetDelay:            0,
+				TorrentDelay:           0,
+				BypassIfHighestQuality: false,
+				Order:                  1,
+				Tags:                   []int{11},
+				ID:                     10,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "delayProfile"),
+			ExpectedMethod: "POST",
+			WithRequest: &radarr.DelayProfile{
+				EnableUsenet:           false,
+				EnableTorrent:          true,
+				PreferredProtocol:      "torrent",
+				UsenetDelay:            0,
+				TorrentDelay:           0,
+				BypassIfHighestQuality: false,
+				Order:                  1,
+				Tags:                   []int{11},
+			},
+			ExpectedRequest: delayProfileRequest,
+			ResponseStatus:  404,
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.DelayProfile)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddDelayProfile(test.WithRequest.(*radarr.DelayProfile))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateDelayProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "delayProfile", "10"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 200,
+			WithRequest: &radarr.DelayProfile{
+				EnableTorrent: true,
+				ID:            10,
+				Tags:          []int{11},
+			},
+			ExpectedRequest: `{"enableTorrent":true,"id":10,"tags":[11]}` + "\n",
+			ResponseBody:    secondDelayProfile,
+			WithResponse: &radarr.DelayProfile{
+				EnableUsenet:           false,
+				EnableTorrent:          true,
+				PreferredProtocol:      "torrent",
+				UsenetDelay:            0,
+				TorrentDelay:           0,
+				BypassIfHighestQuality: false,
+				Order:                  1,
+				Tags:                   []int{11},
+				ID:                     10,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "delayProfile", "10"),
+			ExpectedMethod: "PUT",
+			WithRequest: &radarr.DelayProfile{
+				EnableTorrent: true,
+				ID:            10,
+				Tags:          []int{11},
+			},
+			ExpectedRequest: `{"enableTorrent":true,"id":10,"tags":[11]}` + "\n",
+			ResponseStatus:  404,
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.DelayProfile)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateDelayProfile(test.WithRequest.(*radarr.DelayProfile))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteDelayProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "delayProfile", "10"),
+			ExpectedMethod: "DELETE",
+			ResponseStatus: 200,
+			WithRequest:    int64(10),
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "delayProfile", "10"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(10),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*radarr.DelayProfile)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteDelayProfile(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}

--- a/sonarr/delayprofile.go
+++ b/sonarr/delayprofile.go
@@ -15,15 +15,15 @@ const bpDelayProfile = APIver + "/delayProfile"
 
 // DelayProfile is the /api/v3/delayprofile endpoint.
 type DelayProfile struct {
-	EnableUsenet           bool   `json:"enableUsenet"`
-	EnableTorrent          bool   `json:"enableTorrent"`
-	BypassIfHighestQuality bool   `json:"bypassIfHighestQuality"`
-	UsenetDelay            int64  `json:"usenetDelay"`
-	TorrentDelay           int64  `json:"torrentDelay"`
+	EnableUsenet           bool   `json:"enableUsenet,omitempty"`
+	EnableTorrent          bool   `json:"enableTorrent,omitempty"`
+	BypassIfHighestQuality bool   `json:"bypassIfHighestQuality,omitempty"`
+	UsenetDelay            int64  `json:"usenetDelay,omitempty"`
+	TorrentDelay           int64  `json:"torrentDelay,omitempty"`
 	ID                     int64  `json:"id,omitempty"`
-	Order                  int64  `json:"order"`
+	Order                  int64  `json:"order,omitempty"`
 	Tags                   []int  `json:"tags"`
-	PreferredProtocol      string `json:"preferredProtocol"`
+	PreferredProtocol      string `json:"preferredProtocol,omitempty"`
 }
 
 // GetDelayProfiles returns all configured delay profiles.

--- a/sonarr/delayprofile.go
+++ b/sonarr/delayprofile.go
@@ -61,6 +61,8 @@ func (s *Sonarr) GetDelayProfileContext(ctx context.Context, profileID int64) (*
 }
 
 // AddDelayProfile creates a delay profile.
+// AddDelayProfile doesn't take into account the "order" field sent on creation.
+// Order will be set to first available. This can only be edited via UpdateDelayProfile later on.
 func (s *Sonarr) AddDelayProfile(profile *DelayProfile) (*DelayProfile, error) {
 	return s.AddDelayProfileContext(context.Background(), profile)
 }

--- a/sonarr/delayprofile_test.go
+++ b/sonarr/delayprofile_test.go
@@ -1,0 +1,310 @@
+package sonarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/sonarr"
+)
+
+const (
+	firstDelayProfile = `{
+		"enableUsenet": true,
+		"enableTorrent": true,
+		"preferredProtocol": "usenet",
+		"usenetDelay": 0,
+		"torrentDelay": 0,
+		"bypassIfHighestQuality": true,
+		"order": 2147483647,
+		"tags": [],
+		"id": 1
+	}`
+	secondDelayProfile = `{
+		"enableUsenet": false,
+		"enableTorrent": true,
+		"preferredProtocol": "torrent",
+		"usenetDelay": 0,
+		"torrentDelay": 0,
+		"bypassIfHighestQuality": false,
+		"order": 1,
+		"tags": [11],
+		"id": 10
+	}`
+	delayProfileRequest = `{"enableTorrent":true,"order":1,"tags":[11],"preferredProtocol":"torrent"}` + "\n"
+)
+
+func TestGetDelayProfiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "delayProfile"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   `[` + firstDelayProfile + `,` + secondDelayProfile + `]`,
+			WithResponse: []*sonarr.DelayProfile{
+				{
+					EnableUsenet:           true,
+					EnableTorrent:          true,
+					PreferredProtocol:      "usenet",
+					UsenetDelay:            0,
+					TorrentDelay:           0,
+					BypassIfHighestQuality: true,
+					Order:                  2147483647,
+					Tags:                   []int{},
+					ID:                     1,
+				},
+				{
+					EnableUsenet:           false,
+					EnableTorrent:          true,
+					PreferredProtocol:      "torrent",
+					UsenetDelay:            0,
+					TorrentDelay:           0,
+					BypassIfHighestQuality: false,
+					Order:                  1,
+					Tags:                   []int{11},
+					ID:                     10,
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "delayProfile"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   []*sonarr.DelayProfile(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDelayProfiles()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetDelayProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "delayProfile/1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			WithRequest:    int64(1),
+			ResponseBody:   firstDelayProfile,
+			WithResponse: &sonarr.DelayProfile{
+				EnableUsenet:           true,
+				EnableTorrent:          true,
+				PreferredProtocol:      "usenet",
+				UsenetDelay:            0,
+				TorrentDelay:           0,
+				BypassIfHighestQuality: true,
+				Order:                  2147483647,
+				Tags:                   []int{},
+				ID:                     1,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "delayProfile", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			WithRequest:    int64(1),
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*sonarr.DelayProfile)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDelayProfile(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddDelayProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "delayProfile"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 200,
+			WithRequest: &sonarr.DelayProfile{
+				EnableUsenet:           false,
+				EnableTorrent:          true,
+				PreferredProtocol:      "torrent",
+				UsenetDelay:            0,
+				TorrentDelay:           0,
+				BypassIfHighestQuality: false,
+				Order:                  1,
+				Tags:                   []int{11},
+			},
+			ExpectedRequest: delayProfileRequest,
+			ResponseBody:    secondDelayProfile,
+			WithResponse: &sonarr.DelayProfile{
+				EnableUsenet:           false,
+				EnableTorrent:          true,
+				PreferredProtocol:      "torrent",
+				UsenetDelay:            0,
+				TorrentDelay:           0,
+				BypassIfHighestQuality: false,
+				Order:                  1,
+				Tags:                   []int{11},
+				ID:                     10,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "delayProfile"),
+			ExpectedMethod: "POST",
+			WithRequest: &sonarr.DelayProfile{
+				EnableUsenet:           false,
+				EnableTorrent:          true,
+				PreferredProtocol:      "torrent",
+				UsenetDelay:            0,
+				TorrentDelay:           0,
+				BypassIfHighestQuality: false,
+				Order:                  1,
+				Tags:                   []int{11},
+			},
+			ExpectedRequest: delayProfileRequest,
+			ResponseStatus:  404,
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*sonarr.DelayProfile)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddDelayProfile(test.WithRequest.(*sonarr.DelayProfile))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateDelayProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "delayProfile", "10"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 200,
+			WithRequest: &sonarr.DelayProfile{
+				EnableTorrent: true,
+				ID:            10,
+				Tags:          []int{11},
+			},
+			ExpectedRequest: `{"enableTorrent":true,"id":10,"tags":[11]}` + "\n",
+			ResponseBody:    secondDelayProfile,
+			WithResponse: &sonarr.DelayProfile{
+				EnableUsenet:           false,
+				EnableTorrent:          true,
+				PreferredProtocol:      "torrent",
+				UsenetDelay:            0,
+				TorrentDelay:           0,
+				BypassIfHighestQuality: false,
+				Order:                  1,
+				Tags:                   []int{11},
+				ID:                     10,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "delayProfile", "10"),
+			ExpectedMethod: "PUT",
+			WithRequest: &sonarr.DelayProfile{
+				EnableTorrent: true,
+				ID:            10,
+				Tags:          []int{11},
+			},
+			ExpectedRequest: `{"enableTorrent":true,"id":10,"tags":[11]}` + "\n",
+			ResponseStatus:  404,
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*sonarr.DelayProfile)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateDelayProfile(test.WithRequest.(*sonarr.DelayProfile))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteDelayProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "delayProfile", "10"),
+			ExpectedMethod: "DELETE",
+			ResponseStatus: 200,
+			WithRequest:    int64(10),
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "delayProfile", "10"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(10),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*sonarr.DelayProfile)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteDelayProfile(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}


### PR DESCRIPTION
- add radarr delayprofile
- add sonarr delayprofile tests
- update omitempty tags of sonarr delayprofile

To keep in mind: response of create delayprofile doesn't take into account the "order" field sent on creation. This can only be edited after via update.