### PR TITLE
feat(radarr): indexer

### DIFF
--- a/radarr/indexer.go
+++ b/radarr/indexer.go
@@ -1,0 +1,142 @@
+package radarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+const bpIndexer = APIver + "/indexer"
+
+// IndexerInput is the input for a new or updated indexer.
+type IndexerInput struct {
+	EnableAutomaticSearch   bool                `json:"enableAutomaticSearch"`
+	EnableInteractiveSearch bool                `json:"enableInteractiveSearch"`
+	EnableRss               bool                `json:"enableRss"`
+	DownloadClientID        int64               `json:"downloadClientId"`
+	Priority                int64               `json:"priority"`
+	ID                      int64               `json:"id,omitempty"`
+	ConfigContract          string              `json:"configContract"`
+	Implementation          string              `json:"implementation"`
+	Name                    string              `json:"name"`
+	Protocol                string              `json:"protocol"`
+	Tags                    []int               `json:"tags"`
+	Fields                  []*starr.FieldInput `json:"fields"`
+}
+
+// IndexerOutput is the output from the indexer methods.
+type IndexerOutput struct {
+	EnableAutomaticSearch   bool                 `json:"enableAutomaticSearch"`
+	EnableInteractiveSearch bool                 `json:"enableInteractiveSearch"`
+	EnableRss               bool                 `json:"enableRss"`
+	SupportsRss             bool                 `json:"supportsRss"`
+	SupportsSearch          bool                 `json:"supportsSearch"`
+	DownloadClientID        int64                `json:"DownloadClientID"`
+	Priority                int64                `json:"priority"`
+	ID                      int64                `json:"id,omitempty"`
+	ConfigContract          string               `json:"configContract"`
+	Implementation          string               `json:"implementation"`
+	ImplementationName      string               `json:"implementationName"`
+	InfoLink                string               `json:"infoLink"`
+	Name                    string               `json:"name"`
+	Protocol                string               `json:"protocol"`
+	Tags                    []int                `json:"tags"`
+	Fields                  []*starr.FieldOutput `json:"fields"`
+}
+
+// GetIndexers returns all configured indexers.
+func (r *Radarr) GetIndexers() ([]*IndexerOutput, error) {
+	return r.GetIndexersContext(context.Background())
+}
+
+// GetIndexersContext returns all configured indexers.
+func (r *Radarr) GetIndexersContext(ctx context.Context) ([]*IndexerOutput, error) {
+	var output []*IndexerOutput
+
+	req := starr.Request{URI: bpIndexer}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetIndexer returns a single indexer.
+func (r *Radarr) GetIndexer(indexerID int64) (*IndexerOutput, error) {
+	return r.GetIndexerContext(context.Background(), indexerID)
+}
+
+// GetIndGetIndexerContextexer returns a single indexer.
+func (r *Radarr) GetIndexerContext(ctx context.Context, indexerID int64) (*IndexerOutput, error) {
+	var output IndexerOutput
+
+	req := starr.Request{URI: path.Join(bpIndexer, fmt.Sprint(indexerID))}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// AddIndexer creates a indexer.
+func (r *Radarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
+	return r.AddIndexerContext(context.Background(), indexer)
+}
+
+// AddIndexerContext creates a indexer.
+func (r *Radarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
+	var output IndexerOutput
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
+	}
+
+	req := starr.Request{URI: bpIndexer, Body: &body}
+	if err := r.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateIndexer updates the indexer.
+func (r *Radarr) UpdateIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
+	return r.UpdateIndexerContext(context.Background(), indexer)
+}
+
+// UpdateIndexerContext updates the indexer.
+func (r *Radarr) UpdateIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
+	var output IndexerOutput
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpIndexer, fmt.Sprint(indexer.ID)), Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// DeleteIndexer removes a single indexer.
+func (r *Radarr) DeleteIndexer(indexerID int64) error {
+	return r.DeleteIndexerContext(context.Background(), indexerID)
+}
+
+// DeleteIndexerContext removes a single indexer.
+func (r *Radarr) DeleteIndexerContext(ctx context.Context, indexerID int64) error {
+	req := starr.Request{URI: path.Join(bpIndexer, fmt.Sprint(indexerID))}
+	if err := r.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/radarr/indexer_test.go
+++ b/radarr/indexer_test.go
@@ -1,0 +1,477 @@
+package radarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+)
+
+const indexerResponseBody = `{
+	"enableRss": true,
+	"enableAutomaticSearch": true,
+	"enableInteractiveSearch": true,
+	"supportsRss": true,
+	"supportsSearch": true,
+	"protocol": "usenet",
+	"priority": 25,
+	"downloadClientId": 0,
+	"name": "NZBgeek",
+	"fields": [
+	  {
+		"order": 0,
+		"name": "baseUrl",
+		"label": "URL",
+		"value": "https://api.nzbgeek.info",
+		"type": "textbox",
+		"advanced": false
+	  },
+	  {
+		"order": 1,
+		"name": "apiPath",
+		"label": "API Path",
+		"helpText": "Path to the api, usually /api",
+		"value": "/api",
+		"type": "textbox",
+		"advanced": true
+	  }
+	],
+	"implementationName": "Newznab",
+	"implementation": "Newznab",
+	"configContract": "NewznabSettings",
+	"infoLink": "https://wiki.servarr.com/radarr/supported#newznab",
+	"tags": [],
+	"id": 1
+  }`
+
+const addIndexer = `{"enableAutomaticSearch":true,"enableInteractiveSearch":true,"enableRss":true,` +
+	`"downloadClientId":0,"priority":25,"configContract":"NewznabSettings","implementation":"Newznab"` +
+	`,"name":"NZBgeek","protocol":"usenet","tags":[],` +
+	`"fields":[{"name":"baseUrl","value":"https://api.nzbgeek.info"},{"name":"apiPath","value":"/api"}]}`
+
+const updateIndexer = `{"enableAutomaticSearch":true,"enableInteractiveSearch":true,"enableRss":true,` +
+	`"downloadClientId":0,"priority":25,"id":1,"configContract":"NewznabSettings","implementation":"Newznab",` +
+	`"name":"NZBgeek","protocol":"usenet","tags":[],` +
+	`"fields":[{"name":"baseUrl","value":"https://api.nzbgeek.info"},{"name":"apiPath","value":"/api"}]}`
+
+func TestGetIndexers(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, radarr.APIver, "indexer"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    "[" + indexerResponseBody + "]",
+			WithRequest:     nil,
+			WithResponse: []*radarr.IndexerOutput{
+				{
+					EnableAutomaticSearch:   true,
+					EnableInteractiveSearch: true,
+					EnableRss:               true,
+					SupportsRss:             true,
+					SupportsSearch:          true,
+					Priority:                25,
+					ID:                      1,
+					ConfigContract:          "NewznabSettings",
+					Implementation:          "Newznab",
+					ImplementationName:      "Newznab",
+					InfoLink:                "https://wiki.servarr.com/radarr/supported#newznab",
+					Name:                    "NZBgeek",
+					Protocol:                "usenet",
+					Fields: []*starr.FieldOutput{
+						{
+							Order:    0,
+							Name:     "baseUrl",
+							Label:    "URL",
+							Value:    "https://api.nzbgeek.info",
+							Type:     "textbox",
+							Advanced: false,
+						},
+						{
+							Order:    1,
+							Name:     "apiPath",
+							Label:    "API Path",
+							HelpText: "Path to the api, usually /api",
+							Value:    "/api",
+							Type:     "textbox",
+							Advanced: true,
+						},
+					},
+					Tags: []int{},
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   ([]*radarr.IndexerOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetIndexers()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetIndexer(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, radarr.APIver, "indexer", "1"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    indexerResponseBody,
+			WithRequest:     nil,
+			WithResponse: &radarr.IndexerOutput{
+				EnableAutomaticSearch:   true,
+				EnableInteractiveSearch: true,
+				EnableRss:               true,
+				SupportsRss:             true,
+				SupportsSearch:          true,
+				Priority:                25,
+				ID:                      1,
+				ConfigContract:          "NewznabSettings",
+				Implementation:          "Newznab",
+				ImplementationName:      "Newznab",
+				InfoLink:                "https://wiki.servarr.com/radarr/supported#newznab",
+				Name:                    "NZBgeek",
+				Protocol:                "usenet",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "baseUrl",
+						Label:    "URL",
+						Value:    "https://api.nzbgeek.info",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "apiPath",
+						Label:    "API Path",
+						HelpText: "Path to the api, usually /api",
+						Value:    "/api",
+						Type:     "textbox",
+						Advanced: true,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*radarr.IndexerOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetIndexer(1)
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddIndexer(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 200,
+			WithRequest: &radarr.IndexerInput{
+				EnableAutomaticSearch:   true,
+				EnableInteractiveSearch: true,
+				EnableRss:               true,
+				DownloadClientID:        0,
+				Priority:                25,
+				ConfigContract:          "NewznabSettings",
+				Implementation:          "Newznab",
+				Name:                    "NZBgeek",
+				Protocol:                "usenet",
+				Tags:                    []int{},
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "baseUrl",
+						Value: "https://api.nzbgeek.info",
+					},
+					{
+						Name:  "apiPath",
+						Value: "/api",
+					},
+				},
+			},
+			ExpectedRequest: addIndexer + "\n",
+			ResponseBody:    indexerResponseBody,
+			WithResponse: &radarr.IndexerOutput{
+				EnableAutomaticSearch:   true,
+				EnableInteractiveSearch: true,
+				EnableRss:               true,
+				SupportsRss:             true,
+				SupportsSearch:          true,
+				Priority:                25,
+				ID:                      1,
+				ConfigContract:          "NewznabSettings",
+				Implementation:          "Newznab",
+				ImplementationName:      "Newznab",
+				InfoLink:                "https://wiki.servarr.com/radarr/supported#newznab",
+				Name:                    "NZBgeek",
+				Protocol:                "usenet",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "baseUrl",
+						Label:    "URL",
+						Value:    "https://api.nzbgeek.info",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "apiPath",
+						Label:    "API Path",
+						HelpText: "Path to the api, usually /api",
+						Value:    "/api",
+						Type:     "textbox",
+						Advanced: true,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 404,
+			WithRequest: &radarr.IndexerInput{
+				EnableAutomaticSearch:   true,
+				EnableInteractiveSearch: true,
+				EnableRss:               true,
+				DownloadClientID:        0,
+				Priority:                25,
+				ConfigContract:          "NewznabSettings",
+				Implementation:          "Newznab",
+				Name:                    "NZBgeek",
+				Protocol:                "usenet",
+				Tags:                    []int{},
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "baseUrl",
+						Value: "https://api.nzbgeek.info",
+					},
+					{
+						Name:  "apiPath",
+						Value: "/api",
+					},
+				},
+			},
+			ExpectedRequest: addIndexer + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.IndexerOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddIndexer(test.WithRequest.(*radarr.IndexerInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateIndexer(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer", "1"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 200,
+			WithRequest: &radarr.IndexerInput{
+				EnableAutomaticSearch:   true,
+				EnableInteractiveSearch: true,
+				EnableRss:               true,
+				DownloadClientID:        0,
+				Priority:                25,
+				ConfigContract:          "NewznabSettings",
+				Implementation:          "Newznab",
+				Name:                    "NZBgeek",
+				Protocol:                "usenet",
+				Tags:                    []int{},
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "baseUrl",
+						Value: "https://api.nzbgeek.info",
+					},
+					{
+						Name:  "apiPath",
+						Value: "/api",
+					},
+				},
+				ID: 1,
+			},
+			ExpectedRequest: updateIndexer + "\n",
+			ResponseBody:    indexerResponseBody,
+			WithResponse: &radarr.IndexerOutput{
+				EnableAutomaticSearch:   true,
+				EnableInteractiveSearch: true,
+				EnableRss:               true,
+				SupportsRss:             true,
+				SupportsSearch:          true,
+				Priority:                25,
+				ID:                      1,
+				ConfigContract:          "NewznabSettings",
+				Implementation:          "Newznab",
+				ImplementationName:      "Newznab",
+				InfoLink:                "https://wiki.servarr.com/radarr/supported#newznab",
+				Name:                    "NZBgeek",
+				Protocol:                "usenet",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "baseUrl",
+						Label:    "URL",
+						Value:    "https://api.nzbgeek.info",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "apiPath",
+						Label:    "API Path",
+						HelpText: "Path to the api, usually /api",
+						Value:    "/api",
+						Type:     "textbox",
+						Advanced: true,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer", "1"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 404,
+			WithRequest: &radarr.IndexerInput{
+				EnableAutomaticSearch:   true,
+				EnableInteractiveSearch: true,
+				EnableRss:               true,
+				DownloadClientID:        0,
+				Priority:                25,
+				ConfigContract:          "NewznabSettings",
+				Implementation:          "Newznab",
+				Name:                    "NZBgeek",
+				Protocol:                "usenet",
+				Tags:                    []int{},
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "baseUrl",
+						Value: "https://api.nzbgeek.info",
+					},
+					{
+						Name:  "apiPath",
+						Value: "/api",
+					},
+				},
+				ID: 1,
+			},
+			ExpectedRequest: updateIndexer + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.IndexerOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateIndexer(test.WithRequest.(*radarr.IndexerInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteIndexer(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 200,
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteIndexer(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}

--- a/radarr/indexerconfig.go
+++ b/radarr/indexerconfig.go
@@ -1,0 +1,65 @@
+package radarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+const bpIndexerConfig = APIver + "/config/indexer"
+
+// IndexerConfig represents the /config/indexer endpoint.
+type IndexerConfig struct {
+	WhitelistedHardcodedSubs string `json:"whitelistedHardcodedSubs"`
+	ID                       int64  `json:"id"`
+	MaximumSize              int64  `json:"maximumSize"`
+	MinimumAge               int64  `json:"minimumAge"`
+	Retention                int64  `json:"retention"`
+	RssSyncInterval          int64  `json:"rssSyncInterval"`
+	AvailabilityDelay        int    `json:"availabilityDelay"`
+	PreferIndexerFlags       bool   `json:"preferIndexerFlags"`
+	AllowHardcodedSubs       bool   `json:"allowHardcodedSubs"`
+}
+
+// GetIndexerConfig returns an Indexer Config.
+func (r *Radarr) GetIndexerConfig() (*IndexerConfig, error) {
+	return r.GetIndexerConfigContext(context.Background())
+}
+
+// GetIndexerConfigContext returns the indexer Config.
+func (r *Radarr) GetIndexerConfigContext(ctx context.Context) (*IndexerConfig, error) {
+	var output IndexerConfig
+
+	req := starr.Request{URI: bpIndexerConfig}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateIndexerConfig update the single indexerConfig.
+func (r *Radarr) UpdateIndexerConfig(indexerConfig *IndexerConfig) (*IndexerConfig, error) {
+	return r.UpdateIndexerConfigContext(context.Background(), indexerConfig)
+}
+
+// UpdateIndexerConfigContext update the single indexerConfig.
+func (r *Radarr) UpdateIndexerConfigContext(ctx context.Context, indexerConfig *IndexerConfig) (*IndexerConfig, error) {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(indexerConfig); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexerConfig, err)
+	}
+
+	var output IndexerConfig
+
+	req := starr.Request{URI: path.Join(bpIndexerConfig, fmt.Sprint(indexerConfig.ID)), Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}

--- a/radarr/indexerconfig_test.go
+++ b/radarr/indexerconfig_test.go
@@ -1,0 +1,142 @@
+package radarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+)
+
+const indexerConfigBody = `{
+	"minimumAge": 0,
+	"maximumSize": 0,
+	"retention": 0,
+	"rssSyncInterval": 60,
+	"preferIndexerFlags": false,
+	"availabilityDelay": 0,
+	"allowHardcodedSubs": false,
+	"whitelistedHardcodedSubs": "",
+	"id": 1
+  }`
+
+const indexerRequest = `{"whitelistedHardcodedSubs":"","id":1,"maximumSize":0,"minimumAge":0,"retention":0,` +
+	`"rssSyncInterval":60,"availabilityDelay":0,"preferIndexerFlags":false,"allowHardcodedSubs":false}` + "\n"
+
+func TestGetIndexerConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "config", "indexer"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   indexerConfigBody,
+			WithResponse: &radarr.IndexerConfig{
+				WhitelistedHardcodedSubs: "",
+				ID:                       1,
+				MaximumSize:              0,
+				MinimumAge:               0,
+				Retention:                0,
+				RssSyncInterval:          60,
+				AvailabilityDelay:        0,
+				PreferIndexerFlags:       false,
+				AllowHardcodedSubs:       false,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "config", "indexer"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*radarr.IndexerConfig)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetIndexerConfig()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateIndexerConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "202",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "config", "indexer", "1"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 202,
+			WithRequest: &radarr.IndexerConfig{
+				WhitelistedHardcodedSubs: "",
+				ID:                       1,
+				MaximumSize:              0,
+				MinimumAge:               0,
+				Retention:                0,
+				RssSyncInterval:          60,
+				AvailabilityDelay:        0,
+				PreferIndexerFlags:       false,
+				AllowHardcodedSubs:       false,
+			},
+			ExpectedRequest: indexerRequest,
+			ResponseBody:    indexerConfigBody,
+			WithResponse: &radarr.IndexerConfig{
+				WhitelistedHardcodedSubs: "",
+				ID:                       1,
+				MaximumSize:              0,
+				MinimumAge:               0,
+				Retention:                0,
+				RssSyncInterval:          60,
+				AvailabilityDelay:        0,
+				PreferIndexerFlags:       false,
+				AllowHardcodedSubs:       false,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "config", "indexer", "1"),
+			ExpectedMethod: "PUT",
+			WithRequest: &radarr.IndexerConfig{
+				ID:                 1,
+				MaximumSize:        0,
+				MinimumAge:         0,
+				Retention:          0,
+				RssSyncInterval:    60,
+				AvailabilityDelay:  0,
+				PreferIndexerFlags: false,
+				AllowHardcodedSubs: false,
+			},
+			ExpectedRequest: indexerRequest,
+			ResponseStatus:  404,
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.IndexerConfig)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateIndexerConfig(test.WithRequest.(*radarr.IndexerConfig))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}

--- a/radarr/restriction.go
+++ b/radarr/restriction.go
@@ -1,0 +1,114 @@
+package radarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+const bpRestriction = APIver + "/restriction"
+
+// Restriction is the input for a new or updated restriction.
+type Restriction struct {
+	Tags     []int  `json:"tags,omitempty"`
+	Required string `json:"required,omitempty"`
+	Ignored  string `json:"ignored,omitempty"`
+	ID       int64  `json:"id,omitempty"`
+}
+
+// GetRestrictions returns all configured restrictions.
+func (r *Radarr) GetRestrictions() ([]*Restriction, error) {
+	return r.GetRestrictionsContext(context.Background())
+}
+
+// GetRestrictionsContext returns all configured restrictions.
+func (r *Radarr) GetRestrictionsContext(ctx context.Context) ([]*Restriction, error) {
+	var output []*Restriction
+
+	req := starr.Request{URI: bpRestriction}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetRestriction returns a single restriction.
+func (r *Radarr) GetRestriction(restrictionID int64) (*Restriction, error) {
+	return r.GetRestrictionContext(context.Background(), restrictionID)
+}
+
+// GetIndGetRestrictionContextexer returns a single restriction.
+func (r *Radarr) GetRestrictionContext(ctx context.Context, restrictionID int64) (*Restriction, error) {
+	var output Restriction
+
+	req := starr.Request{URI: path.Join(bpRestriction, fmt.Sprint(restrictionID))}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// AddRestriction creates a restriction.
+func (r *Radarr) AddRestriction(restriction *Restriction) (*Restriction, error) {
+	return r.AddRestrictionContext(context.Background(), restriction)
+}
+
+// AddRestrictionContext creates a restriction.
+func (r *Radarr) AddRestrictionContext(ctx context.Context, restriction *Restriction) (*Restriction, error) {
+	var output Restriction
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(restriction); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpRestriction, err)
+	}
+
+	req := starr.Request{URI: bpRestriction, Body: &body}
+	if err := r.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateRestriction updates the restriction.
+func (r *Radarr) UpdateRestriction(restriction *Restriction) (*Restriction, error) {
+	return r.UpdateRestrictionContext(context.Background(), restriction)
+}
+
+// UpdateRestrictionContext updates the restriction.
+func (r *Radarr) UpdateRestrictionContext(ctx context.Context, restriction *Restriction) (*Restriction, error) {
+	var output Restriction
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(restriction); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpRestriction, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpRestriction, fmt.Sprint(restriction.ID)), Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// DeleteRestriction removes a single restriction.
+func (r *Radarr) DeleteRestriction(restrictionID int64) error {
+	return r.DeleteRestrictionContext(context.Background(), restrictionID)
+}
+
+// DeleteRestrictionContext removes a single restriction.
+func (r *Radarr) DeleteRestrictionContext(ctx context.Context, restrictionID int64) error {
+	req := starr.Request{URI: path.Join(bpRestriction, fmt.Sprint(restrictionID))}
+	if err := r.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/radarr/restriction_test.go
+++ b/radarr/restriction_test.go
@@ -1,0 +1,247 @@
+package radarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+)
+
+const restrictionBody = `{
+	"required": "test1",
+	"ignored": "test2",
+	"tags": [],
+	"id": 2
+  }`
+
+func TestGetRestrictions(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "restriction"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   "[" + restrictionBody + "]",
+			WithResponse: []*radarr.Restriction{
+				{
+					Tags:     []int{},
+					Required: "test1",
+					Ignored:  "test2",
+					ID:       2,
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "restriction"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   []*radarr.Restriction(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetRestrictions()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetRestriction(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "restriction", "2"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			WithRequest:    int64(2),
+			ResponseBody:   restrictionBody,
+			WithResponse: &radarr.Restriction{
+				Tags:     []int{},
+				Required: "test1",
+				Ignored:  "test2",
+				ID:       2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "restriction", "2"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			WithRequest:    int64(2),
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithResponse:   (*radarr.Restriction)(nil),
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetRestriction(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddRestriction(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "restriction"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 200,
+			WithRequest: &radarr.Restriction{
+				Required: "test1",
+				Ignored:  "test2",
+			},
+			ExpectedRequest: `{"required":"test1","ignored":"test2"}` + "\n",
+			ResponseBody:    restrictionBody,
+			WithResponse: &radarr.Restriction{
+				Tags:     []int{},
+				Required: "test1",
+				Ignored:  "test2",
+				ID:       2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "restriction"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 404,
+			WithRequest: &radarr.Restriction{
+				Required: "test1",
+				Ignored:  "test2",
+			},
+			ExpectedRequest: `{"required":"test1","ignored":"test2"}` + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.Restriction)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddRestriction(test.WithRequest.(*radarr.Restriction))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateRestriction(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "restriction", "2"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 200,
+			WithRequest: &radarr.Restriction{
+				Required: "test1",
+				Ignored:  "test2",
+				ID:       2,
+			},
+			ExpectedRequest: `{"required":"test1","ignored":"test2","id":2}` + "\n",
+			ResponseBody:    restrictionBody,
+			WithResponse: &radarr.Restriction{
+				Tags:     []int{},
+				Required: "test1",
+				Ignored:  "test2",
+				ID:       2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "restriction", "2"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 404,
+			WithRequest: &radarr.Restriction{
+				Required: "test1",
+				Ignored:  "test2",
+				ID:       2,
+			},
+			ExpectedRequest: `{"required":"test1","ignored":"test2","id":2}` + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.Restriction)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateRestriction(test.WithRequest.(*radarr.Restriction))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteRestriction(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "restriction", "1"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(1),
+			ResponseStatus: 200,
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "restriction", "1"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(1),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteRestriction(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}


### PR DESCRIPTION
- add indexer methods
- add indexer config methods
- add restriction methods

Indexer is the same as sonarr. However I noticed that is a bit different in lidarr. For now, I think it'll be better to keep them separated.