### PR TITLE
feat: download client

### DIFF
--- a/lidarr/downloadclient.go
+++ b/lidarr/downloadclient.go
@@ -1,0 +1,143 @@
+package lidarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for download client calls.
+const bpDownloadClient = APIver + "/downloadClient"
+
+// DownloadClientInput is the input for a new or updated download client.
+type DownloadClientInput struct {
+	Enable                   bool                `json:"enable"`
+	RemoveCompletedDownloads bool                `json:"removeCompletedDownloads"`
+	RemoveFailedDownloads    bool                `json:"removeFailedDownloads"`
+	Priority                 int                 `json:"priority"`
+	ID                       int64               `json:"id,omitempty"`
+	ConfigContract           string              `json:"configContract"`
+	Implementation           string              `json:"implementation"`
+	Name                     string              `json:"name"`
+	Protocol                 string              `json:"protocol"`
+	Tags                     []int               `json:"tags"`
+	Fields                   []*starr.FieldInput `json:"fields"`
+}
+
+// DownloadClientOutput is the output from the download client methods.
+type DownloadClientOutput struct {
+	Enable                   bool                 `json:"enable"`
+	RemoveCompletedDownloads bool                 `json:"removeCompletedDownloads"`
+	RemoveFailedDownloads    bool                 `json:"removeFailedDownloads"`
+	Priority                 int                  `json:"priority"`
+	ID                       int64                `json:"id,omitempty"`
+	ConfigContract           string               `json:"configContract"`
+	Implementation           string               `json:"implementation"`
+	ImplementationName       string               `json:"implementationName"`
+	InfoLink                 string               `json:"infoLink"`
+	Name                     string               `json:"name"`
+	Protocol                 string               `json:"protocol"`
+	Tags                     []int                `json:"tags"`
+	Fields                   []*starr.FieldOutput `json:"fields"`
+}
+
+// GetDownloadClients returns all configured download clients.
+func (l *Lidarr) GetDownloadClients() ([]*DownloadClientOutput, error) {
+	return l.GetDownloadClientsContext(context.Background())
+}
+
+// GetDownloadClientsContext returns all configured download clients.
+func (l *Lidarr) GetDownloadClientsContext(ctx context.Context) ([]*DownloadClientOutput, error) {
+	var output []*DownloadClientOutput
+
+	req := starr.Request{URI: bpDownloadClient}
+	if err := l.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetDownloadClient returns a single download client.
+func (l *Lidarr) GetDownloadClient(downloadclientID int64) (*DownloadClientOutput, error) {
+	return l.GetDownloadClientContext(context.Background(), downloadclientID)
+}
+
+// GetDownloadClientContext returns a single download client.
+func (l *Lidarr) GetDownloadClientContext(ctx context.Context, downloadclientID int64) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(downloadclientID))}
+	if err := l.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// AddDownloadClient creates a download client.
+func (l *Lidarr) AddDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
+	return l.AddDownloadClientContext(context.Background(), downloadclient)
+}
+
+// AddDownloadClientContext creates a download client.
+func (l *Lidarr) AddDownloadClientContext(ctx context.Context,
+	client *DownloadClientInput,
+) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(client); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
+	}
+
+	req := starr.Request{URI: bpDownloadClient, Body: &body}
+	if err := l.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateDownloadClient updates the download client.
+func (l *Lidarr) UpdateDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
+	return l.UpdateDownloadClientContext(context.Background(), downloadclient)
+}
+
+// UpdateDownloadClientContext updates the download client.
+func (l *Lidarr) UpdateDownloadClientContext(ctx context.Context,
+	client *DownloadClientInput,
+) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(client); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(client.ID)), Body: &body}
+	if err := l.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// DeleteDownloadClient removes a single download client.
+func (l *Lidarr) DeleteDownloadClient(downloadclientID int64) error {
+	return l.DeleteDownloadClientContext(context.Background(), downloadclientID)
+}
+
+// DeleteDownloadClientContext removes a single download client.
+func (l *Lidarr) DeleteDownloadClientContext(ctx context.Context, downloadclientID int64) error {
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(downloadclientID))}
+	if err := l.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/lidarr/downloadclient_test.go
+++ b/lidarr/downloadclient_test.go
@@ -1,0 +1,506 @@
+package lidarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/lidarr"
+)
+
+const downloadClientResponseBody = `{
+    "enable": true,
+    "protocol": "torrent",
+    "priority": 1,
+    "removeCompletedDownloads": false,
+    "removeFailedDownloads": false,
+    "name": "Transmission",
+    "fields": [
+        {
+            "order": 0,
+            "name": "host",
+            "label": "Host",
+            "value": "transmission",
+            "type": "textbox",
+            "advanced": false
+        },
+        {
+            "order": 1,
+            "name": "port",
+            "label": "Port",
+            "value": 9091,
+            "type": "textbox",
+            "advanced": false
+        },
+        {
+            "order": 2,
+            "name": "useSsl",
+            "label": "Use SSL",
+            "helpText": "Use secure connection when connecting to Transmission",
+            "value": false,
+            "type": "checkbox",
+            "advanced": false
+        }
+    ],
+    "implementationName": "Transmission",
+    "implementation": "Transmission",
+    "configContract": "TransmissionSettings",
+    "infoLink": "https://wiki.servarr.com/lidarr/supported#transmission",
+    "tags": [],
+    "id": 3
+}`
+
+const addDownloadClient = `{"enable":true,"removeCompletedDownloads":false,"removeFailedDownloads":false,` +
+	`"priority":1,"configContract":"TransmissionSettings","implementation":"Transmission","name":"Transmission",` +
+	`"protocol":"torrent","tags":null,"fields":[{"name":"host","value":"transmission"},` +
+	`{"name":"port","value":9091},{"name":"useSSL","value":false}]}`
+
+const updateDownloadClient = `{"enable":true,"removeCompletedDownloads":false,"removeFailedDownloads":false,` +
+	`"priority":1,"id":3,"configContract":"TransmissionSettings","implementation":"Transmission","name":"Transmission",` +
+	`"protocol":"torrent","tags":null,"fields":[{"name":"host","value":"transmission"},` +
+	`{"name":"port","value":9091},{"name":"useSSL","value":false}]}`
+
+func TestGetDownloadClients(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, lidarr.APIver, "downloadClient"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    "[" + downloadClientResponseBody + "]",
+			WithRequest:     nil,
+			WithResponse: []*lidarr.DownloadClientOutput{
+				{
+					Enable:             true,
+					Priority:           1,
+					ID:                 3,
+					ConfigContract:     "TransmissionSettings",
+					Implementation:     "Transmission",
+					ImplementationName: "Transmission",
+					InfoLink:           "https://wiki.servarr.com/lidarr/supported#transmission",
+					Name:               "Transmission",
+					Protocol:           "torrent",
+					Fields: []*starr.FieldOutput{
+						{
+							Order:    0,
+							Name:     "host",
+							Label:    "Host",
+							Value:    "transmission",
+							Type:     "textbox",
+							Advanced: false,
+						},
+						{
+							Order:    1,
+							Name:     "port",
+							Label:    "Port",
+							Value:    float64(9091),
+							Type:     "textbox",
+							Advanced: false,
+						},
+						{
+							Order:    2,
+							Name:     "useSsl",
+							Label:    "Use SSL",
+							HelpText: "Use secure connection when connecting to Transmission",
+							Value:    false,
+							Type:     "checkbox",
+							Advanced: false,
+						},
+					},
+					Tags: []int{},
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   ([]*lidarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDownloadClients()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, lidarr.APIver, "downloadClient", "1"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    downloadClientResponseBody,
+			WithRequest:     nil,
+			WithResponse: &lidarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/lidarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*lidarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDownloadClient(1)
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 200,
+			WithRequest: &lidarr.DownloadClientInput{
+				Enable:                   true,
+				RemoveCompletedDownloads: false,
+				RemoveFailedDownloads:    false,
+				Priority:                 1,
+				ConfigContract:           "TransmissionSettings",
+				Implementation:           "Transmission",
+				Name:                     "Transmission",
+				Protocol:                 "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+			},
+			ExpectedRequest: addDownloadClient + "\n",
+			ResponseBody:    downloadClientResponseBody,
+			WithResponse: &lidarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/lidarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 404,
+			WithRequest: &lidarr.DownloadClientInput{
+				Enable:                   true,
+				RemoveCompletedDownloads: false,
+				RemoveFailedDownloads:    false,
+				Priority:                 1,
+				ConfigContract:           "TransmissionSettings",
+				Implementation:           "Transmission",
+				Name:                     "Transmission",
+				Protocol:                 "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+			},
+			ExpectedRequest: addDownloadClient + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*lidarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddDownloadClient(test.WithRequest.(*lidarr.DownloadClientInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient", "3"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 200,
+			WithRequest: &lidarr.DownloadClientInput{
+				Enable:                   true,
+				RemoveCompletedDownloads: false,
+				RemoveFailedDownloads:    false,
+				Priority:                 1,
+				ConfigContract:           "TransmissionSettings",
+				Implementation:           "Transmission",
+				Name:                     "Transmission",
+				Protocol:                 "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+				ID: 3,
+			},
+			ExpectedRequest: updateDownloadClient + "\n",
+			ResponseBody:    downloadClientResponseBody,
+			WithResponse: &lidarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/lidarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient", "3"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 404,
+			WithRequest: &lidarr.DownloadClientInput{
+				Enable:                   true,
+				RemoveCompletedDownloads: false,
+				RemoveFailedDownloads:    false,
+				Priority:                 1,
+				ConfigContract:           "TransmissionSettings",
+				Implementation:           "Transmission",
+				Name:                     "Transmission",
+				Protocol:                 "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+				ID: 3,
+			},
+			ExpectedRequest: updateDownloadClient + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*lidarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateDownloadClient(test.WithRequest.(*lidarr.DownloadClientInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 200,
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteDownloadClient(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}

--- a/lidarr/downloadclientconfig.go
+++ b/lidarr/downloadclientconfig.go
@@ -1,0 +1,63 @@
+package lidarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for download client config calls.
+const bpDownloadClientConfig = APIver + "/config/downloadClient"
+
+// DownloadClientConfig is the /api/v1/config/downloadClientConfig endpoint.
+type DownloadClientConfig struct {
+	EnableCompletedDownloadHandling bool   `json:"enableCompletedDownloadHandling"`
+	AutoRedownloadFailed            bool   `json:"autoRedownloadFailed"`
+	ID                              int64  `json:"id"`
+	DownloadClientWorkingFolders    string `json:"downloadClientWorkingFolders"`
+}
+
+// GetDownloadClientConfig returns the download client config.
+func (l *Lidarr) GetDownloadClientConfig() (*DownloadClientConfig, error) {
+	return l.GetDownloadClientConfigContext(context.Background())
+}
+
+// GetDownloadClientConfig returns the download client config.
+func (l *Lidarr) GetDownloadClientConfigContext(ctx context.Context) (*DownloadClientConfig, error) {
+	var output DownloadClientConfig
+
+	req := starr.Request{URI: bpDownloadClientConfig}
+	if err := l.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateDownloadClientConfig update the single download client config.
+func (l *Lidarr) UpdateDownloadClientConfig(downloadClientConfig *DownloadClientConfig) (*DownloadClientConfig, error) {
+	return l.UpdateDownloadClientConfigContext(context.Background(), downloadClientConfig)
+}
+
+// UpdateDownloadClientConfig update the single download client config.
+func (l *Lidarr) UpdateDownloadClientConfigContext(ctx context.Context,
+	config *DownloadClientConfig,
+) (*DownloadClientConfig, error) {
+	var output DownloadClientConfig
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(config); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClientConfig, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpDownloadClientConfig, fmt.Sprint(config.ID)), Body: &body}
+	if err := l.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}

--- a/lidarr/downloadclientconfig_test.go
+++ b/lidarr/downloadclientconfig_test.go
@@ -1,0 +1,119 @@
+package lidarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/lidarr"
+)
+
+const downloadClientConfigBody = `{
+    "downloadClientWorkingFolders": "_UNPACK_|_FAILED_",
+    "enableCompletedDownloadHandling": true,
+    "autoRedownloadFailed": false,
+    "id": 1
+}`
+
+func TestGetDownloadClientConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, lidarr.APIver, "config", "downloadClient"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    downloadClientConfigBody,
+			WithRequest:     nil,
+			WithResponse: &lidarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling: true,
+				AutoRedownloadFailed:            false,
+				ID:                              1,
+				DownloadClientWorkingFolders:    "_UNPACK_|_FAILED_",
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "config", "downloadClient"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*lidarr.DownloadClientConfig)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDownloadClientConfig()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateDownloadClientConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "202",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "config", "downloadClient", "1"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 202,
+			WithRequest: &lidarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling: true,
+				AutoRedownloadFailed:            false,
+				ID:                              1,
+				DownloadClientWorkingFolders:    "_UNPACK_|_FAILED_",
+			},
+			ExpectedRequest: `{"enableCompletedDownloadHandling":true,"autoRedownloadFailed":false,` +
+				`"id":1,"downloadClientWorkingFolders":"_UNPACK_|_FAILED_"}` + "\n",
+			ResponseBody: downloadClientConfigBody,
+			WithResponse: &lidarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling: true,
+				AutoRedownloadFailed:            false,
+				ID:                              1,
+				DownloadClientWorkingFolders:    "_UNPACK_|_FAILED_",
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "config", "downloadClient", "1"),
+			ExpectedMethod: "PUT",
+			WithRequest: &lidarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling: true,
+				AutoRedownloadFailed:            false,
+				ID:                              1,
+				DownloadClientWorkingFolders:    "_UNPACK_|_FAILED_",
+			},
+			ExpectedRequest: `{"enableCompletedDownloadHandling":true,"autoRedownloadFailed":false,` +
+				`"id":1,"downloadClientWorkingFolders":"_UNPACK_|_FAILED_"}` + "\n",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*lidarr.DownloadClientConfig)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateDownloadClientConfig(test.WithRequest.(*lidarr.DownloadClientConfig))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}

--- a/lidarr/remotepathmapping.go
+++ b/lidarr/remotepathmapping.go
@@ -13,22 +13,14 @@ import (
 // Define Base Path for remote path mapping calls.
 const bpRemotePathMapping = APIver + "/remotePathMapping"
 
-// RemotePathMapping is the /api/v1/remotePathMapping endpoint.
-type RemotePathMapping struct {
-	ID         int64  `json:"id,omitempty"`
-	Host       string `json:"host"`
-	RemotePath string `json:"remotePath"`
-	LocalPath  string `json:"localPath"`
-}
-
 // GetRemotePathMappings returns all configured remote path mappings.
-func (l *Lidarr) GetRemotePathMappings() ([]*RemotePathMapping, error) {
+func (l *Lidarr) GetRemotePathMappings() ([]*starr.RemotePathMapping, error) {
 	return l.GetRemotePathMappingsContext(context.Background())
 }
 
 // GetRemotePathMappingsContext returns all configured remote path mappings.
-func (l *Lidarr) GetRemotePathMappingsContext(ctx context.Context) ([]*RemotePathMapping, error) {
-	var output []*RemotePathMapping
+func (l *Lidarr) GetRemotePathMappingsContext(ctx context.Context) ([]*starr.RemotePathMapping, error) {
+	var output []*starr.RemotePathMapping
 
 	req := starr.Request{URI: bpRemotePathMapping}
 	if err := l.GetInto(ctx, req, &output); err != nil {
@@ -39,13 +31,13 @@ func (l *Lidarr) GetRemotePathMappingsContext(ctx context.Context) ([]*RemotePat
 }
 
 // GetRemotePathMapping returns a single remote path mapping.
-func (l *Lidarr) GetRemotePathMapping(mappingID int64) (*RemotePathMapping, error) {
+func (l *Lidarr) GetRemotePathMapping(mappingID int64) (*starr.RemotePathMapping, error) {
 	return l.GetRemotePathMappingContext(context.Background(), mappingID)
 }
 
 // GetRemotePathMappingContext returns a single remote path mapping.
-func (l *Lidarr) GetRemotePathMappingContext(ctx context.Context, mappingID int64) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+func (l *Lidarr) GetRemotePathMappingContext(ctx context.Context, mappingID int64) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mappingID))}
 	if err := l.GetInto(ctx, req, &output); err != nil {
@@ -56,15 +48,15 @@ func (l *Lidarr) GetRemotePathMappingContext(ctx context.Context, mappingID int6
 }
 
 // AddRemotePathMapping creates a remote path mapping.
-func (l *Lidarr) AddRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+func (l *Lidarr) AddRemotePathMapping(mapping *starr.RemotePathMapping) (*starr.RemotePathMapping, error) {
 	return l.AddRemotePathMappingContext(context.Background(), mapping)
 }
 
 // AddRemotePathMappingContext creates a remote path mapping.
 func (l *Lidarr) AddRemotePathMappingContext(ctx context.Context,
-	mapping *RemotePathMapping,
-) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+	mapping *starr.RemotePathMapping,
+) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(mapping); err != nil {
@@ -80,15 +72,15 @@ func (l *Lidarr) AddRemotePathMappingContext(ctx context.Context,
 }
 
 // UpdateRemotePathMapping updates the remote path mapping.
-func (l *Lidarr) UpdateRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+func (l *Lidarr) UpdateRemotePathMapping(mapping *starr.RemotePathMapping) (*starr.RemotePathMapping, error) {
 	return l.UpdateRemotePathMappingContext(context.Background(), mapping)
 }
 
 // UpdateRemotePathMappingContext updates the remote path mapping.
 func (l *Lidarr) UpdateRemotePathMappingContext(ctx context.Context,
-	mapping *RemotePathMapping,
-) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+	mapping *starr.RemotePathMapping,
+) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(mapping); err != nil {

--- a/lidarr/remotepathmapping.go
+++ b/lidarr/remotepathmapping.go
@@ -1,0 +1,119 @@
+package lidarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for remote path mapping calls.
+const bpRemotePathMapping = APIver + "/remotePathMapping"
+
+// RemotePathMapping is the /api/v1/remotePathMapping endpoint.
+type RemotePathMapping struct {
+	ID         int64  `json:"id,omitempty"`
+	Host       string `json:"host"`
+	RemotePath string `json:"remotePath"`
+	LocalPath  string `json:"localPath"`
+}
+
+// GetRemotePathMappings returns all configured remote path mappings.
+func (l *Lidarr) GetRemotePathMappings() ([]*RemotePathMapping, error) {
+	return l.GetRemotePathMappingsContext(context.Background())
+}
+
+// GetRemotePathMappingsContext returns all configured remote path mappings.
+func (l *Lidarr) GetRemotePathMappingsContext(ctx context.Context) ([]*RemotePathMapping, error) {
+	var output []*RemotePathMapping
+
+	req := starr.Request{URI: bpRemotePathMapping}
+	if err := l.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetRemotePathMapping returns a single remote path mapping.
+func (l *Lidarr) GetRemotePathMapping(mappingID int64) (*RemotePathMapping, error) {
+	return l.GetRemotePathMappingContext(context.Background(), mappingID)
+}
+
+// GetRemotePathMappingContext returns a single remote path mapping.
+func (l *Lidarr) GetRemotePathMappingContext(ctx context.Context, mappingID int64) (*RemotePathMapping, error) {
+	var output RemotePathMapping
+
+	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mappingID))}
+	if err := l.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// AddRemotePathMapping creates a remote path mapping.
+func (l *Lidarr) AddRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+	return l.AddRemotePathMappingContext(context.Background(), mapping)
+}
+
+// AddRemotePathMappingContext creates a remote path mapping.
+func (l *Lidarr) AddRemotePathMappingContext(ctx context.Context,
+	mapping *RemotePathMapping,
+) (*RemotePathMapping, error) {
+	var output RemotePathMapping
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(mapping); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpRemotePathMapping, err)
+	}
+
+	req := starr.Request{URI: bpRemotePathMapping, Body: &body}
+	if err := l.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateRemotePathMapping updates the remote path mapping.
+func (l *Lidarr) UpdateRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+	return l.UpdateRemotePathMappingContext(context.Background(), mapping)
+}
+
+// UpdateRemotePathMappingContext updates the remote path mapping.
+func (l *Lidarr) UpdateRemotePathMappingContext(ctx context.Context,
+	mapping *RemotePathMapping,
+) (*RemotePathMapping, error) {
+	var output RemotePathMapping
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(mapping); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpRemotePathMapping, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mapping.ID)), Body: &body}
+	if err := l.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// DeleteRemotePathMapping removes a single remote path mapping.
+func (l *Lidarr) DeleteRemotePathMapping(mappingID int64) error {
+	return l.DeleteRemotePathMappingContext(context.Background(), mappingID)
+}
+
+// DeleteRemotePathMappingContext removes a single remote path mapping.
+func (l *Lidarr) DeleteRemotePathMappingContext(ctx context.Context, mappingID int64) error {
+	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mappingID))}
+	if err := l.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/lidarr/remotepathmapping_test.go
+++ b/lidarr/remotepathmapping_test.go
@@ -28,7 +28,7 @@ func TestGetRemotePathMappings(t *testing.T) {
 			ExpectedMethod: "GET",
 			ResponseStatus: 200,
 			ResponseBody:   `[` + remotePathMapping + `]`,
-			WithResponse: []*lidarr.RemotePathMapping{
+			WithResponse: []*starr.RemotePathMapping{
 				{
 					Host:       "transmission",
 					RemotePath: "/remote/",
@@ -45,7 +45,7 @@ func TestGetRemotePathMappings(t *testing.T) {
 			ResponseStatus: 404,
 			ResponseBody:   `{"message": "NotFound"}`,
 			WithError:      starr.ErrInvalidStatusCode,
-			WithResponse:   []*lidarr.RemotePathMapping(nil),
+			WithResponse:   []*starr.RemotePathMapping(nil),
 		},
 	}
 
@@ -73,7 +73,7 @@ func TestGetRemotePathMapping(t *testing.T) {
 			ResponseStatus: 200,
 			WithRequest:    int64(1),
 			ResponseBody:   remotePathMapping,
-			WithResponse: &lidarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -88,7 +88,7 @@ func TestGetRemotePathMapping(t *testing.T) {
 			ResponseStatus: 404,
 			WithRequest:    int64(1),
 			ResponseBody:   `{"message": "NotFound"}`,
-			WithResponse:   (*lidarr.RemotePathMapping)(nil),
+			WithResponse:   (*starr.RemotePathMapping)(nil),
 			WithError:      starr.ErrInvalidStatusCode,
 		},
 	}
@@ -115,14 +115,14 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 201,
-			WithRequest: &lidarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
 			},
 			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    remotePathMapping,
-			WithResponse: &lidarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -135,7 +135,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
-			WithRequest: &lidarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -143,7 +143,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    `{"message": "NotFound"}`,
 			WithError:       starr.ErrInvalidStatusCode,
-			WithResponse:    (*lidarr.RemotePathMapping)(nil),
+			WithResponse:    (*starr.RemotePathMapping)(nil),
 		},
 	}
 
@@ -153,7 +153,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			t.Parallel()
 			mockServer := test.GetMockServer(t)
 			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
-			output, err := client.AddRemotePathMapping(test.WithRequest.(*lidarr.RemotePathMapping))
+			output, err := client.AddRemotePathMapping(test.WithRequest.(*starr.RemotePathMapping))
 			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
@@ -169,7 +169,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping", "2"),
 			ExpectedMethod: "PUT",
 			ResponseStatus: 201,
-			WithRequest: &lidarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -177,7 +177,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			},
 			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    remotePathMapping,
-			WithResponse: &lidarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -190,7 +190,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping", "2"),
 			ExpectedMethod: "PUT",
 			ResponseStatus: 404,
-			WithRequest: &lidarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -199,7 +199,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    `{"message": "NotFound"}`,
 			WithError:       starr.ErrInvalidStatusCode,
-			WithResponse:    (*lidarr.RemotePathMapping)(nil),
+			WithResponse:    (*starr.RemotePathMapping)(nil),
 		},
 	}
 
@@ -209,7 +209,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			t.Parallel()
 			mockServer := test.GetMockServer(t)
 			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
-			output, err := client.UpdateRemotePathMapping(test.WithRequest.(*lidarr.RemotePathMapping))
+			output, err := client.UpdateRemotePathMapping(test.WithRequest.(*starr.RemotePathMapping))
 			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})

--- a/lidarr/remotepathmapping_test.go
+++ b/lidarr/remotepathmapping_test.go
@@ -1,0 +1,253 @@
+package lidarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/lidarr"
+)
+
+const (
+	remotePathMapping = `{
+		"host": "transmission",
+		"remotePath": "/remote/",
+		"localPath": "/local/",
+		"id": 2
+	}`
+)
+
+func TestGetRemotePathMappings(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   `[` + remotePathMapping + `]`,
+			WithResponse: []*lidarr.RemotePathMapping{
+				{
+					Host:       "transmission",
+					RemotePath: "/remote/",
+					LocalPath:  "/local/",
+					ID:         2,
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   []*lidarr.RemotePathMapping(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetRemotePathMappings()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			WithRequest:    int64(1),
+			ResponseBody:   remotePathMapping,
+			WithResponse: &lidarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			WithRequest:    int64(1),
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithResponse:   (*lidarr.RemotePathMapping)(nil),
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetRemotePathMapping(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "201",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 201,
+			WithRequest: &lidarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+			},
+			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    remotePathMapping,
+			WithResponse: &lidarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 404,
+			WithRequest: &lidarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+			},
+			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*lidarr.RemotePathMapping)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddRemotePathMapping(test.WithRequest.(*lidarr.RemotePathMapping))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "201",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 201,
+			WithRequest: &lidarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    remotePathMapping,
+			WithResponse: &lidarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 404,
+			WithRequest: &lidarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*lidarr.RemotePathMapping)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateRemotePathMapping(test.WithRequest.(*lidarr.RemotePathMapping))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 200,
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteRemotePathMapping(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}

--- a/prowlarr/downloadclient.go
+++ b/prowlarr/downloadclient.go
@@ -1,0 +1,139 @@
+package prowlarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for download client calls.
+const bpDownloadClient = APIver + "/downloadClient"
+
+// DownloadClientInput is the input for a new or updated download client.
+type DownloadClientInput struct {
+	Enable         bool                `json:"enable"`
+	Priority       int                 `json:"priority"`
+	ID             int64               `json:"id,omitempty"`
+	ConfigContract string              `json:"configContract"`
+	Implementation string              `json:"implementation"`
+	Name           string              `json:"name"`
+	Protocol       string              `json:"protocol"`
+	Tags           []int               `json:"tags"`
+	Fields         []*starr.FieldInput `json:"fields"`
+}
+
+// DownloadClientOutput is the output from the download client methods.
+type DownloadClientOutput struct {
+	Enable             bool                 `json:"enable"`
+	Priority           int                  `json:"priority"`
+	ID                 int64                `json:"id,omitempty"`
+	ConfigContract     string               `json:"configContract"`
+	Implementation     string               `json:"implementation"`
+	ImplementationName string               `json:"implementationName"`
+	InfoLink           string               `json:"infoLink"`
+	Name               string               `json:"name"`
+	Protocol           string               `json:"protocol"`
+	Tags               []int                `json:"tags"`
+	Fields             []*starr.FieldOutput `json:"fields"`
+}
+
+// GetDownloadClients returns all configured download clients.
+func (p *Prowlarr) GetDownloadClients() ([]*DownloadClientOutput, error) {
+	return p.GetDownloadClientsContext(context.Background())
+}
+
+// GetDownloadClientsContext returns all configured download clients.
+func (p *Prowlarr) GetDownloadClientsContext(ctx context.Context) ([]*DownloadClientOutput, error) {
+	var output []*DownloadClientOutput
+
+	req := starr.Request{URI: bpDownloadClient}
+	if err := p.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetDownloadClient returns a single download client.
+func (p *Prowlarr) GetDownloadClient(downloadclientID int64) (*DownloadClientOutput, error) {
+	return p.GetDownloadClientContext(context.Background(), downloadclientID)
+}
+
+// GetDownloadClientContext returns a single download client.
+func (p *Prowlarr) GetDownloadClientContext(ctx context.Context, clientID int64) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(clientID))}
+	if err := p.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// AddDownloadClient creates a download client.
+func (p *Prowlarr) AddDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
+	return p.AddDownloadClientContext(context.Background(), downloadclient)
+}
+
+// AddDownloadClientContext creates a download client.
+func (p *Prowlarr) AddDownloadClientContext(ctx context.Context,
+	client *DownloadClientInput,
+) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(client); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
+	}
+
+	req := starr.Request{URI: bpDownloadClient, Body: &body}
+	if err := p.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateDownloadClient updates the download client.
+func (p *Prowlarr) UpdateDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
+	return p.UpdateDownloadClientContext(context.Background(), downloadclient)
+}
+
+// UpdateDownloadClientContext updates the download client.
+func (p *Prowlarr) UpdateDownloadClientContext(ctx context.Context,
+	client *DownloadClientInput,
+) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(client); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(client.ID)), Body: &body}
+	if err := p.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// DeleteDownloadClient removes a single download client.
+func (p *Prowlarr) DeleteDownloadClient(downloadclientID int64) error {
+	return p.DeleteDownloadClientContext(context.Background(), downloadclientID)
+}
+
+// DeleteDownloadClientContext removes a single download client.
+func (p *Prowlarr) DeleteDownloadClientContext(ctx context.Context, downloadclientID int64) error {
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(downloadclientID))}
+	if err := p.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/prowlarr/downloadclient_test.go
+++ b/prowlarr/downloadclient_test.go
@@ -1,0 +1,494 @@
+package prowlarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/prowlarr"
+)
+
+const downloadClientResponseBody = `{
+    "enable": true,
+    "protocol": "torrent",
+    "priority": 1,
+    "name": "Transmission",
+    "fields": [
+        {
+            "order": 0,
+            "name": "host",
+            "label": "Host",
+            "value": "transmission",
+            "type": "textbox",
+            "advanced": false
+        },
+        {
+            "order": 1,
+            "name": "port",
+            "label": "Port",
+            "value": 9091,
+            "type": "textbox",
+            "advanced": false
+        },
+        {
+            "order": 2,
+            "name": "useSsl",
+            "label": "Use SSL",
+            "helpText": "Use secure connection when connecting to Transmission",
+            "value": false,
+            "type": "checkbox",
+            "advanced": false
+        }
+    ],
+    "implementationName": "Transmission",
+    "implementation": "Transmission",
+    "configContract": "TransmissionSettings",
+    "infoLink": "https://wiki.servarr.com/prowlarr/supported#transmission",
+    "tags": [],
+    "id": 3
+}`
+
+const addDownloadClient = `{"enable":true,"priority":1,"configContract":"TransmissionSettings",` +
+	`"implementation":"Transmission","name":"Transmission","protocol":"torrent","tags":null,"fields":` +
+	`[{"name":"host","value":"transmission"},{"name":"port","value":9091},{"name":"useSSL","value":false}]}`
+
+const updateDownloadClient = `{"enable":true,"priority":1,"id":3,"configContract":"TransmissionSettings",` +
+	`"implementation":"Transmission","name":"Transmission","protocol":"torrent","tags":null,"fields":` +
+	`[{"name":"host","value":"transmission"},{"name":"port","value":9091},{"name":"useSSL","value":false}]}`
+
+func TestGetDownloadClients(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, prowlarr.APIver, "downloadClient"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    "[" + downloadClientResponseBody + "]",
+			WithRequest:     nil,
+			WithResponse: []*prowlarr.DownloadClientOutput{
+				{
+					Enable:             true,
+					Priority:           1,
+					ID:                 3,
+					ConfigContract:     "TransmissionSettings",
+					Implementation:     "Transmission",
+					ImplementationName: "Transmission",
+					InfoLink:           "https://wiki.servarr.com/prowlarr/supported#transmission",
+					Name:               "Transmission",
+					Protocol:           "torrent",
+					Fields: []*starr.FieldOutput{
+						{
+							Order:    0,
+							Name:     "host",
+							Label:    "Host",
+							Value:    "transmission",
+							Type:     "textbox",
+							Advanced: false,
+						},
+						{
+							Order:    1,
+							Name:     "port",
+							Label:    "Port",
+							Value:    float64(9091),
+							Type:     "textbox",
+							Advanced: false,
+						},
+						{
+							Order:    2,
+							Name:     "useSsl",
+							Label:    "Use SSL",
+							HelpText: "Use secure connection when connecting to Transmission",
+							Value:    false,
+							Type:     "checkbox",
+							Advanced: false,
+						},
+					},
+					Tags: []int{},
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   ([]*prowlarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDownloadClients()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, prowlarr.APIver, "downloadClient", "1"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    downloadClientResponseBody,
+			WithRequest:     nil,
+			WithResponse: &prowlarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/prowlarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*prowlarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDownloadClient(1)
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 200,
+			WithRequest: &prowlarr.DownloadClientInput{
+				Enable:         true,
+				Priority:       1,
+				ConfigContract: "TransmissionSettings",
+				Implementation: "Transmission",
+				Name:           "Transmission",
+				Protocol:       "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+			},
+			ExpectedRequest: addDownloadClient + "\n",
+			ResponseBody:    downloadClientResponseBody,
+			WithResponse: &prowlarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/prowlarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 404,
+			WithRequest: &prowlarr.DownloadClientInput{
+				Enable:         true,
+				Priority:       1,
+				ConfigContract: "TransmissionSettings",
+				Implementation: "Transmission",
+				Name:           "Transmission",
+				Protocol:       "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+			},
+			ExpectedRequest: addDownloadClient + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*prowlarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddDownloadClient(test.WithRequest.(*prowlarr.DownloadClientInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient", "3"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 200,
+			WithRequest: &prowlarr.DownloadClientInput{
+				Enable:         true,
+				Priority:       1,
+				ConfigContract: "TransmissionSettings",
+				Implementation: "Transmission",
+				Name:           "Transmission",
+				Protocol:       "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+				ID: 3,
+			},
+			ExpectedRequest: updateDownloadClient + "\n",
+			ResponseBody:    downloadClientResponseBody,
+			WithResponse: &prowlarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/prowlarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient", "3"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 404,
+			WithRequest: &prowlarr.DownloadClientInput{
+				Enable:         true,
+				Priority:       1,
+				ConfigContract: "TransmissionSettings",
+				Implementation: "Transmission",
+				Name:           "Transmission",
+				Protocol:       "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+				ID: 3,
+			},
+			ExpectedRequest: updateDownloadClient + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*prowlarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateDownloadClient(test.WithRequest.(*prowlarr.DownloadClientInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 200,
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteDownloadClient(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}

--- a/radarr/downloadclient.go
+++ b/radarr/downloadclient.go
@@ -1,0 +1,143 @@
+package radarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for download client calls.
+const bpDownloadClient = APIver + "/downloadClient"
+
+// DownloadClientInput is the input for a new or updated download client.
+type DownloadClientInput struct {
+	Enable                   bool                `json:"enable"`
+	RemoveCompletedDownloads bool                `json:"removeCompletedDownloads"`
+	RemoveFailedDownloads    bool                `json:"removeFailedDownloads"`
+	Priority                 int                 `json:"priority"`
+	ID                       int64               `json:"id,omitempty"`
+	ConfigContract           string              `json:"configContract"`
+	Implementation           string              `json:"implementation"`
+	Name                     string              `json:"name"`
+	Protocol                 string              `json:"protocol"`
+	Tags                     []int               `json:"tags"`
+	Fields                   []*starr.FieldInput `json:"fields"`
+}
+
+// DownloadClientOutput is the output from the download client methods.
+type DownloadClientOutput struct {
+	Enable                   bool                 `json:"enable"`
+	RemoveCompletedDownloads bool                 `json:"removeCompletedDownloads"`
+	RemoveFailedDownloads    bool                 `json:"removeFailedDownloads"`
+	Priority                 int                  `json:"priority"`
+	ID                       int64                `json:"id,omitempty"`
+	ConfigContract           string               `json:"configContract"`
+	Implementation           string               `json:"implementation"`
+	ImplementationName       string               `json:"implementationName"`
+	InfoLink                 string               `json:"infoLink"`
+	Name                     string               `json:"name"`
+	Protocol                 string               `json:"protocol"`
+	Tags                     []int                `json:"tags"`
+	Fields                   []*starr.FieldOutput `json:"fields"`
+}
+
+// GetDownloadClients returns all configured download clients.
+func (r *Radarr) GetDownloadClients() ([]*DownloadClientOutput, error) {
+	return r.GetDownloadClientsContext(context.Background())
+}
+
+// GetDownloadClientsContext returns all configured download clients.
+func (r *Radarr) GetDownloadClientsContext(ctx context.Context) ([]*DownloadClientOutput, error) {
+	var output []*DownloadClientOutput
+
+	req := starr.Request{URI: bpDownloadClient}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetDownloadClient returns a single download client.
+func (r *Radarr) GetDownloadClient(downloadclientID int64) (*DownloadClientOutput, error) {
+	return r.GetDownloadClientContext(context.Background(), downloadclientID)
+}
+
+// GetDownloadClientContext returns a single download client.
+func (r *Radarr) GetDownloadClientContext(ctx context.Context, downloadclientID int64) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(downloadclientID))}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// AddDownloadClient creates a download client.
+func (r *Radarr) AddDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
+	return r.AddDownloadClientContext(context.Background(), downloadclient)
+}
+
+// AddDownloadClientContext creates a download client.
+func (r *Radarr) AddDownloadClientContext(ctx context.Context,
+	client *DownloadClientInput,
+) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(client); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
+	}
+
+	req := starr.Request{URI: bpDownloadClient, Body: &body}
+	if err := r.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateDownloadClient updates the download client.
+func (r *Radarr) UpdateDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
+	return r.UpdateDownloadClientContext(context.Background(), downloadclient)
+}
+
+// UpdateDownloadClientContext updates the download client.
+func (r *Radarr) UpdateDownloadClientContext(ctx context.Context,
+	client *DownloadClientInput,
+) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(client); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(client.ID)), Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// DeleteDownloadClient removes a single download client.
+func (r *Radarr) DeleteDownloadClient(downloadclientID int64) error {
+	return r.DeleteDownloadClientContext(context.Background(), downloadclientID)
+}
+
+// DeleteDownloadClientContext removes a single download client.
+func (r *Radarr) DeleteDownloadClientContext(ctx context.Context, downloadclientID int64) error {
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(downloadclientID))}
+	if err := r.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/radarr/downloadclient_test.go
+++ b/radarr/downloadclient_test.go
@@ -1,0 +1,506 @@
+package radarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+)
+
+const downloadClientResponseBody = `{
+    "enable": true,
+    "protocol": "torrent",
+    "priority": 1,
+    "removeCompletedDownloads": false,
+    "removeFailedDownloads": false,
+    "name": "Transmission",
+    "fields": [
+        {
+            "order": 0,
+            "name": "host",
+            "label": "Host",
+            "value": "transmission",
+            "type": "textbox",
+            "advanced": false
+        },
+        {
+            "order": 1,
+            "name": "port",
+            "label": "Port",
+            "value": 9091,
+            "type": "textbox",
+            "advanced": false
+        },
+        {
+            "order": 2,
+            "name": "useSsl",
+            "label": "Use SSL",
+            "helpText": "Use secure connection when connecting to Transmission",
+            "value": false,
+            "type": "checkbox",
+            "advanced": false
+        }
+    ],
+    "implementationName": "Transmission",
+    "implementation": "Transmission",
+    "configContract": "TransmissionSettings",
+    "infoLink": "https://wiki.servarr.com/radarr/supported#transmission",
+    "tags": [],
+    "id": 3
+}`
+
+const addDownloadClient = `{"enable":true,"removeCompletedDownloads":false,"removeFailedDownloads":false,` +
+	`"priority":1,"configContract":"TransmissionSettings","implementation":"Transmission","name":"Transmission",` +
+	`"protocol":"torrent","tags":null,"fields":[{"name":"host","value":"transmission"},` +
+	`{"name":"port","value":9091},{"name":"useSSL","value":false}]}`
+
+const updateDownloadClient = `{"enable":true,"removeCompletedDownloads":false,"removeFailedDownloads":false,` +
+	`"priority":1,"id":3,"configContract":"TransmissionSettings","implementation":"Transmission","name":"Transmission",` +
+	`"protocol":"torrent","tags":null,"fields":[{"name":"host","value":"transmission"},` +
+	`{"name":"port","value":9091},{"name":"useSSL","value":false}]}`
+
+func TestGetDownloadClients(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, radarr.APIver, "downloadClient"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    "[" + downloadClientResponseBody + "]",
+			WithRequest:     nil,
+			WithResponse: []*radarr.DownloadClientOutput{
+				{
+					Enable:             true,
+					Priority:           1,
+					ID:                 3,
+					ConfigContract:     "TransmissionSettings",
+					Implementation:     "Transmission",
+					ImplementationName: "Transmission",
+					InfoLink:           "https://wiki.servarr.com/radarr/supported#transmission",
+					Name:               "Transmission",
+					Protocol:           "torrent",
+					Fields: []*starr.FieldOutput{
+						{
+							Order:    0,
+							Name:     "host",
+							Label:    "Host",
+							Value:    "transmission",
+							Type:     "textbox",
+							Advanced: false,
+						},
+						{
+							Order:    1,
+							Name:     "port",
+							Label:    "Port",
+							Value:    float64(9091),
+							Type:     "textbox",
+							Advanced: false,
+						},
+						{
+							Order:    2,
+							Name:     "useSsl",
+							Label:    "Use SSL",
+							HelpText: "Use secure connection when connecting to Transmission",
+							Value:    false,
+							Type:     "checkbox",
+							Advanced: false,
+						},
+					},
+					Tags: []int{},
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   ([]*radarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDownloadClients()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, radarr.APIver, "downloadClient", "1"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    downloadClientResponseBody,
+			WithRequest:     nil,
+			WithResponse: &radarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/radarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*radarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDownloadClient(1)
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 200,
+			WithRequest: &radarr.DownloadClientInput{
+				Enable:                   true,
+				RemoveCompletedDownloads: false,
+				RemoveFailedDownloads:    false,
+				Priority:                 1,
+				ConfigContract:           "TransmissionSettings",
+				Implementation:           "Transmission",
+				Name:                     "Transmission",
+				Protocol:                 "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+			},
+			ExpectedRequest: addDownloadClient + "\n",
+			ResponseBody:    downloadClientResponseBody,
+			WithResponse: &radarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/radarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 404,
+			WithRequest: &radarr.DownloadClientInput{
+				Enable:                   true,
+				RemoveCompletedDownloads: false,
+				RemoveFailedDownloads:    false,
+				Priority:                 1,
+				ConfigContract:           "TransmissionSettings",
+				Implementation:           "Transmission",
+				Name:                     "Transmission",
+				Protocol:                 "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+			},
+			ExpectedRequest: addDownloadClient + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddDownloadClient(test.WithRequest.(*radarr.DownloadClientInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient", "3"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 200,
+			WithRequest: &radarr.DownloadClientInput{
+				Enable:                   true,
+				RemoveCompletedDownloads: false,
+				RemoveFailedDownloads:    false,
+				Priority:                 1,
+				ConfigContract:           "TransmissionSettings",
+				Implementation:           "Transmission",
+				Name:                     "Transmission",
+				Protocol:                 "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+				ID: 3,
+			},
+			ExpectedRequest: updateDownloadClient + "\n",
+			ResponseBody:    downloadClientResponseBody,
+			WithResponse: &radarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/radarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient", "3"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 404,
+			WithRequest: &radarr.DownloadClientInput{
+				Enable:                   true,
+				RemoveCompletedDownloads: false,
+				RemoveFailedDownloads:    false,
+				Priority:                 1,
+				ConfigContract:           "TransmissionSettings",
+				Implementation:           "Transmission",
+				Name:                     "Transmission",
+				Protocol:                 "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+				ID: 3,
+			},
+			ExpectedRequest: updateDownloadClient + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateDownloadClient(test.WithRequest.(*radarr.DownloadClientInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 200,
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteDownloadClient(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}

--- a/radarr/downloadclientconfig.go
+++ b/radarr/downloadclientconfig.go
@@ -1,0 +1,64 @@
+package radarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for download client config calls.
+const bpDownloadClientConfig = APIver + "/config/downloadClient"
+
+// DownloadClientConfig is the /api/v3/config/downloadClientConfig endpoint.
+type DownloadClientConfig struct {
+	EnableCompletedDownloadHandling  bool   `json:"enableCompletedDownloadHandling"`
+	AutoRedownloadFailed             bool   `json:"autoRedownloadFailed"`
+	CheckForFinishedDownloadInterval int64  `json:"checkForFinishedDownloadInterval"`
+	ID                               int64  `json:"id"`
+	DownloadClientWorkingFolders     string `json:"downloadClientWorkingFolders"`
+}
+
+// GetDownloadClientConfig returns the download client config.
+func (r *Radarr) GetDownloadClientConfig() (*DownloadClientConfig, error) {
+	return r.GetDownloadClientConfigContext(context.Background())
+}
+
+// GetDownloadClientConfig returns the download client config.
+func (r *Radarr) GetDownloadClientConfigContext(ctx context.Context) (*DownloadClientConfig, error) {
+	var output DownloadClientConfig
+
+	req := starr.Request{URI: bpDownloadClientConfig}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateDownloadClientConfig update the single download client config.
+func (r *Radarr) UpdateDownloadClientConfig(downloadClientConfig *DownloadClientConfig) (*DownloadClientConfig, error) {
+	return r.UpdateDownloadClientConfigContext(context.Background(), downloadClientConfig)
+}
+
+// UpdateDownloadClientConfig update the single download client config.
+func (r *Radarr) UpdateDownloadClientConfigContext(ctx context.Context,
+	config *DownloadClientConfig,
+) (*DownloadClientConfig, error) {
+	var output DownloadClientConfig
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(config); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClientConfig, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpDownloadClientConfig, fmt.Sprint(config.ID)), Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}

--- a/radarr/downloadclientconfig_test.go
+++ b/radarr/downloadclientconfig_test.go
@@ -1,0 +1,124 @@
+package radarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+)
+
+const downloadClientConfigBody = `{
+    "downloadClientWorkingFolders": "_UNPACK_|_FAILED_",
+    "enableCompletedDownloadHandling": true,
+	"checkForFinishedDownloadInterval": 1,
+	"autoRedownloadFailed": false,
+    "id": 1
+}`
+
+func TestGetDownloadClientConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, radarr.APIver, "config", "downloadClient"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    downloadClientConfigBody,
+			WithRequest:     nil,
+			WithResponse: &radarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling:  true,
+				AutoRedownloadFailed:             false,
+				CheckForFinishedDownloadInterval: 1,
+				ID:                               1,
+				DownloadClientWorkingFolders:     "_UNPACK_|_FAILED_",
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "config", "downloadClient"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*radarr.DownloadClientConfig)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDownloadClientConfig()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateDownloadClientConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "202",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "config", "downloadClient", "1"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 202,
+			WithRequest: &radarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling:  true,
+				AutoRedownloadFailed:             false,
+				CheckForFinishedDownloadInterval: 1,
+				ID:                               1,
+				DownloadClientWorkingFolders:     "_UNPACK_|_FAILED_",
+			},
+			ExpectedRequest: `{"enableCompletedDownloadHandling":true,"autoRedownloadFailed":false,` +
+				`"checkForFinishedDownloadInterval":1,"id":1,"downloadClientWorkingFolders":"_UNPACK_|_FAILED_"}` + "\n",
+			ResponseBody: downloadClientConfigBody,
+			WithResponse: &radarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling:  true,
+				AutoRedownloadFailed:             false,
+				CheckForFinishedDownloadInterval: 1,
+				ID:                               1,
+				DownloadClientWorkingFolders:     "_UNPACK_|_FAILED_",
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "config", "downloadClient", "1"),
+			ExpectedMethod: "PUT",
+			WithRequest: &radarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling:  true,
+				AutoRedownloadFailed:             false,
+				CheckForFinishedDownloadInterval: 1,
+				ID:                               1,
+				DownloadClientWorkingFolders:     "_UNPACK_|_FAILED_",
+			},
+			ExpectedRequest: `{"enableCompletedDownloadHandling":true,"autoRedownloadFailed":false,` +
+				`"checkForFinishedDownloadInterval":1,"id":1,"downloadClientWorkingFolders":"_UNPACK_|_FAILED_"}` + "\n",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*radarr.DownloadClientConfig)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateDownloadClientConfig(test.WithRequest.(*radarr.DownloadClientConfig))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}

--- a/radarr/remotepathmapping.go
+++ b/radarr/remotepathmapping.go
@@ -13,22 +13,14 @@ import (
 // Define Base Path for remote path mapping calls.
 const bpRemotePathMapping = APIver + "/remotePathMapping"
 
-// RemotePathMapping is the /api/v3/remotePathMapping endpoint.
-type RemotePathMapping struct {
-	ID         int64  `json:"id,omitempty"`
-	Host       string `json:"host"`
-	RemotePath string `json:"remotePath"`
-	LocalPath  string `json:"localPath"`
-}
-
 // GetRemotePathMappings returns all configured remote path mappings.
-func (r *Radarr) GetRemotePathMappings() ([]*RemotePathMapping, error) {
+func (r *Radarr) GetRemotePathMappings() ([]*starr.RemotePathMapping, error) {
 	return r.GetRemotePathMappingsContext(context.Background())
 }
 
 // GetRemotePathMappingsContext returns all configured remote path mappings.
-func (r *Radarr) GetRemotePathMappingsContext(ctx context.Context) ([]*RemotePathMapping, error) {
-	var output []*RemotePathMapping
+func (r *Radarr) GetRemotePathMappingsContext(ctx context.Context) ([]*starr.RemotePathMapping, error) {
+	var output []*starr.RemotePathMapping
 
 	req := starr.Request{URI: bpRemotePathMapping}
 	if err := r.GetInto(ctx, req, &output); err != nil {
@@ -39,13 +31,13 @@ func (r *Radarr) GetRemotePathMappingsContext(ctx context.Context) ([]*RemotePat
 }
 
 // GetRemotePathMapping returns a single remote path mapping.
-func (r *Radarr) GetRemotePathMapping(mappingID int64) (*RemotePathMapping, error) {
+func (r *Radarr) GetRemotePathMapping(mappingID int64) (*starr.RemotePathMapping, error) {
 	return r.GetRemotePathMappingContext(context.Background(), mappingID)
 }
 
 // GetRemotePathMappingContext returns a single remote path mapping.
-func (r *Radarr) GetRemotePathMappingContext(ctx context.Context, mappingID int64) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+func (r *Radarr) GetRemotePathMappingContext(ctx context.Context, mappingID int64) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mappingID))}
 	if err := r.GetInto(ctx, req, &output); err != nil {
@@ -56,15 +48,15 @@ func (r *Radarr) GetRemotePathMappingContext(ctx context.Context, mappingID int6
 }
 
 // AddRemotePathMapping creates a remote path mapping.
-func (r *Radarr) AddRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+func (r *Radarr) AddRemotePathMapping(mapping *starr.RemotePathMapping) (*starr.RemotePathMapping, error) {
 	return r.AddRemotePathMappingContext(context.Background(), mapping)
 }
 
 // AddRemotePathMappingContext creates a remote path mapping.
 func (r *Radarr) AddRemotePathMappingContext(ctx context.Context,
-	mapping *RemotePathMapping,
-) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+	mapping *starr.RemotePathMapping,
+) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(mapping); err != nil {
@@ -80,15 +72,15 @@ func (r *Radarr) AddRemotePathMappingContext(ctx context.Context,
 }
 
 // UpdateRemotePathMapping updates the remote path mapping.
-func (r *Radarr) UpdateRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+func (r *Radarr) UpdateRemotePathMapping(mapping *starr.RemotePathMapping) (*starr.RemotePathMapping, error) {
 	return r.UpdateRemotePathMappingContext(context.Background(), mapping)
 }
 
 // UpdateRemotePathMappingContext updates the remote path mapping.
 func (r *Radarr) UpdateRemotePathMappingContext(ctx context.Context,
-	mapping *RemotePathMapping,
-) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+	mapping *starr.RemotePathMapping,
+) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(mapping); err != nil {

--- a/radarr/remotepathmapping.go
+++ b/radarr/remotepathmapping.go
@@ -1,0 +1,119 @@
+package radarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for remote path mapping calls.
+const bpRemotePathMapping = APIver + "/remotePathMapping"
+
+// RemotePathMapping is the /api/v3/remotePathMapping endpoint.
+type RemotePathMapping struct {
+	ID         int64  `json:"id,omitempty"`
+	Host       string `json:"host"`
+	RemotePath string `json:"remotePath"`
+	LocalPath  string `json:"localPath"`
+}
+
+// GetRemotePathMappings returns all configured remote path mappings.
+func (r *Radarr) GetRemotePathMappings() ([]*RemotePathMapping, error) {
+	return r.GetRemotePathMappingsContext(context.Background())
+}
+
+// GetRemotePathMappingsContext returns all configured remote path mappings.
+func (r *Radarr) GetRemotePathMappingsContext(ctx context.Context) ([]*RemotePathMapping, error) {
+	var output []*RemotePathMapping
+
+	req := starr.Request{URI: bpRemotePathMapping}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetRemotePathMapping returns a single remote path mapping.
+func (r *Radarr) GetRemotePathMapping(mappingID int64) (*RemotePathMapping, error) {
+	return r.GetRemotePathMappingContext(context.Background(), mappingID)
+}
+
+// GetRemotePathMappingContext returns a single remote path mapping.
+func (r *Radarr) GetRemotePathMappingContext(ctx context.Context, mappingID int64) (*RemotePathMapping, error) {
+	var output RemotePathMapping
+
+	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mappingID))}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// AddRemotePathMapping creates a remote path mapping.
+func (r *Radarr) AddRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+	return r.AddRemotePathMappingContext(context.Background(), mapping)
+}
+
+// AddRemotePathMappingContext creates a remote path mapping.
+func (r *Radarr) AddRemotePathMappingContext(ctx context.Context,
+	mapping *RemotePathMapping,
+) (*RemotePathMapping, error) {
+	var output RemotePathMapping
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(mapping); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpRemotePathMapping, err)
+	}
+
+	req := starr.Request{URI: bpRemotePathMapping, Body: &body}
+	if err := r.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateRemotePathMapping updates the remote path mapping.
+func (r *Radarr) UpdateRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+	return r.UpdateRemotePathMappingContext(context.Background(), mapping)
+}
+
+// UpdateRemotePathMappingContext updates the remote path mapping.
+func (r *Radarr) UpdateRemotePathMappingContext(ctx context.Context,
+	mapping *RemotePathMapping,
+) (*RemotePathMapping, error) {
+	var output RemotePathMapping
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(mapping); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpRemotePathMapping, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mapping.ID)), Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// DeleteRemotePathMapping removes a single remote path mapping.
+func (r *Radarr) DeleteRemotePathMapping(mappingID int64) error {
+	return r.DeleteRemotePathMappingContext(context.Background(), mappingID)
+}
+
+// DeleteRemotePathMappingContext removes a single remote path mapping.
+func (r *Radarr) DeleteRemotePathMappingContext(ctx context.Context, mappingID int64) error {
+	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mappingID))}
+	if err := r.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/radarr/remotepathmapping_test.go
+++ b/radarr/remotepathmapping_test.go
@@ -1,0 +1,253 @@
+package radarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+)
+
+const (
+	remotePathMapping = `{
+		"host": "transmission",
+		"remotePath": "/remote/",
+		"localPath": "/local/",
+		"id": 2
+	}`
+)
+
+func TestGetRemotePathMappings(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   `[` + remotePathMapping + `]`,
+			WithResponse: []*radarr.RemotePathMapping{
+				{
+					Host:       "transmission",
+					RemotePath: "/remote/",
+					LocalPath:  "/local/",
+					ID:         2,
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   []*radarr.RemotePathMapping(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetRemotePathMappings()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			WithRequest:    int64(1),
+			ResponseBody:   remotePathMapping,
+			WithResponse: &radarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			WithRequest:    int64(1),
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithResponse:   (*radarr.RemotePathMapping)(nil),
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetRemotePathMapping(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "201",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 201,
+			WithRequest: &radarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+			},
+			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    remotePathMapping,
+			WithResponse: &radarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 404,
+			WithRequest: &radarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+			},
+			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.RemotePathMapping)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddRemotePathMapping(test.WithRequest.(*radarr.RemotePathMapping))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "201",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 201,
+			WithRequest: &radarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    remotePathMapping,
+			WithResponse: &radarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 404,
+			WithRequest: &radarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.RemotePathMapping)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateRemotePathMapping(test.WithRequest.(*radarr.RemotePathMapping))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 200,
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteRemotePathMapping(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}

--- a/radarr/remotepathmapping_test.go
+++ b/radarr/remotepathmapping_test.go
@@ -28,7 +28,7 @@ func TestGetRemotePathMappings(t *testing.T) {
 			ExpectedMethod: "GET",
 			ResponseStatus: 200,
 			ResponseBody:   `[` + remotePathMapping + `]`,
-			WithResponse: []*radarr.RemotePathMapping{
+			WithResponse: []*starr.RemotePathMapping{
 				{
 					Host:       "transmission",
 					RemotePath: "/remote/",
@@ -45,7 +45,7 @@ func TestGetRemotePathMappings(t *testing.T) {
 			ResponseStatus: 404,
 			ResponseBody:   `{"message": "NotFound"}`,
 			WithError:      starr.ErrInvalidStatusCode,
-			WithResponse:   []*radarr.RemotePathMapping(nil),
+			WithResponse:   []*starr.RemotePathMapping(nil),
 		},
 	}
 
@@ -73,7 +73,7 @@ func TestGetRemotePathMapping(t *testing.T) {
 			ResponseStatus: 200,
 			WithRequest:    int64(1),
 			ResponseBody:   remotePathMapping,
-			WithResponse: &radarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -88,7 +88,7 @@ func TestGetRemotePathMapping(t *testing.T) {
 			ResponseStatus: 404,
 			WithRequest:    int64(1),
 			ResponseBody:   `{"message": "NotFound"}`,
-			WithResponse:   (*radarr.RemotePathMapping)(nil),
+			WithResponse:   (*starr.RemotePathMapping)(nil),
 			WithError:      starr.ErrInvalidStatusCode,
 		},
 	}
@@ -115,14 +115,14 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 201,
-			WithRequest: &radarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
 			},
 			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    remotePathMapping,
-			WithResponse: &radarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -135,7 +135,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
-			WithRequest: &radarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -143,7 +143,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    `{"message": "NotFound"}`,
 			WithError:       starr.ErrInvalidStatusCode,
-			WithResponse:    (*radarr.RemotePathMapping)(nil),
+			WithResponse:    (*starr.RemotePathMapping)(nil),
 		},
 	}
 
@@ -153,7 +153,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			t.Parallel()
 			mockServer := test.GetMockServer(t)
 			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
-			output, err := client.AddRemotePathMapping(test.WithRequest.(*radarr.RemotePathMapping))
+			output, err := client.AddRemotePathMapping(test.WithRequest.(*starr.RemotePathMapping))
 			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
@@ -169,7 +169,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping", "2"),
 			ExpectedMethod: "PUT",
 			ResponseStatus: 201,
-			WithRequest: &radarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -177,7 +177,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			},
 			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    remotePathMapping,
-			WithResponse: &radarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -190,7 +190,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "remotePathMapping", "2"),
 			ExpectedMethod: "PUT",
 			ResponseStatus: 404,
-			WithRequest: &radarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -199,7 +199,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    `{"message": "NotFound"}`,
 			WithError:       starr.ErrInvalidStatusCode,
-			WithResponse:    (*radarr.RemotePathMapping)(nil),
+			WithResponse:    (*starr.RemotePathMapping)(nil),
 		},
 	}
 
@@ -209,7 +209,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			t.Parallel()
 			mockServer := test.GetMockServer(t)
 			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
-			output, err := client.UpdateRemotePathMapping(test.WithRequest.(*radarr.RemotePathMapping))
+			output, err := client.UpdateRemotePathMapping(test.WithRequest.(*starr.RemotePathMapping))
 			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})

--- a/readarr/downloadclient.go
+++ b/readarr/downloadclient.go
@@ -1,0 +1,139 @@
+package readarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for download client calls.
+const bpDownloadClient = APIver + "/downloadClient"
+
+// DownloadClientInput is the input for a new or updated download client.
+type DownloadClientInput struct {
+	Enable         bool                `json:"enable"`
+	Priority       int                 `json:"priority"`
+	ID             int64               `json:"id,omitempty"`
+	ConfigContract string              `json:"configContract"`
+	Implementation string              `json:"implementation"`
+	Name           string              `json:"name"`
+	Protocol       string              `json:"protocol"`
+	Tags           []int               `json:"tags"`
+	Fields         []*starr.FieldInput `json:"fields"`
+}
+
+// DownloadClientOutput is the output from the download client methods.
+type DownloadClientOutput struct {
+	Enable             bool                 `json:"enable"`
+	Priority           int                  `json:"priority"`
+	ID                 int64                `json:"id,omitempty"`
+	ConfigContract     string               `json:"configContract"`
+	Implementation     string               `json:"implementation"`
+	ImplementationName string               `json:"implementationName"`
+	InfoLink           string               `json:"infoLink"`
+	Name               string               `json:"name"`
+	Protocol           string               `json:"protocol"`
+	Tags               []int                `json:"tags"`
+	Fields             []*starr.FieldOutput `json:"fields"`
+}
+
+// GetDownloadClients returns all configured download clients.
+func (r *Readarr) GetDownloadClients() ([]*DownloadClientOutput, error) {
+	return r.GetDownloadClientsContext(context.Background())
+}
+
+// GetDownloadClientsContext returns all configured download clients.
+func (r *Readarr) GetDownloadClientsContext(ctx context.Context) ([]*DownloadClientOutput, error) {
+	var output []*DownloadClientOutput
+
+	req := starr.Request{URI: bpDownloadClient}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetDownloadClient returns a single download client.
+func (r *Readarr) GetDownloadClient(downloadclientID int64) (*DownloadClientOutput, error) {
+	return r.GetDownloadClientContext(context.Background(), downloadclientID)
+}
+
+// GetDownloadClientContext returns a single download client.
+func (r *Readarr) GetDownloadClientContext(ctx context.Context, downloadclientID int64) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(downloadclientID))}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// AddDownloadClient creates a download client.
+func (r *Readarr) AddDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
+	return r.AddDownloadClientContext(context.Background(), downloadclient)
+}
+
+// AddDownloadClientContext creates a download client.
+func (r *Readarr) AddDownloadClientContext(ctx context.Context,
+	client *DownloadClientInput,
+) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(client); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
+	}
+
+	req := starr.Request{URI: bpDownloadClient, Body: &body}
+	if err := r.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateDownloadClient updates the download client.
+func (r *Readarr) UpdateDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
+	return r.UpdateDownloadClientContext(context.Background(), downloadclient)
+}
+
+// UpdateDownloadClientContext updates the download client.
+func (r *Readarr) UpdateDownloadClientContext(ctx context.Context,
+	client *DownloadClientInput,
+) (*DownloadClientOutput, error) {
+	var output DownloadClientOutput
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(client); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(client.ID)), Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// DeleteDownloadClient removes a single download client.
+func (r *Readarr) DeleteDownloadClient(downloadclientID int64) error {
+	return r.DeleteDownloadClientContext(context.Background(), downloadclientID)
+}
+
+// DeleteDownloadClientContext removes a single download client.
+func (r *Readarr) DeleteDownloadClientContext(ctx context.Context, downloadclientID int64) error {
+	req := starr.Request{URI: path.Join(bpDownloadClient, fmt.Sprint(downloadclientID))}
+	if err := r.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/readarr/downloadclient_test.go
+++ b/readarr/downloadclient_test.go
@@ -1,0 +1,494 @@
+package readarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/readarr"
+)
+
+const downloadClientResponseBody = `{
+    "enable": true,
+    "protocol": "torrent",
+    "priority": 1,
+    "name": "Transmission",
+    "fields": [
+        {
+            "order": 0,
+            "name": "host",
+            "label": "Host",
+            "value": "transmission",
+            "type": "textbox",
+            "advanced": false
+        },
+        {
+            "order": 1,
+            "name": "port",
+            "label": "Port",
+            "value": 9091,
+            "type": "textbox",
+            "advanced": false
+        },
+        {
+            "order": 2,
+            "name": "useSsl",
+            "label": "Use SSL",
+            "helpText": "Use secure connection when connecting to Transmission",
+            "value": false,
+            "type": "checkbox",
+            "advanced": false
+        }
+    ],
+    "implementationName": "Transmission",
+    "implementation": "Transmission",
+    "configContract": "TransmissionSettings",
+    "infoLink": "https://wiki.servarr.com/readarr/supported#transmission",
+    "tags": [],
+    "id": 3
+}`
+
+const addDownloadClient = `{"enable":true,"priority":1,"configContract":"TransmissionSettings",` +
+	`"implementation":"Transmission","name":"Transmission","protocol":"torrent","tags":null,"fields":` +
+	`[{"name":"host","value":"transmission"},{"name":"port","value":9091},{"name":"useSSL","value":false}]}`
+
+const updateDownloadClient = `{"enable":true,"priority":1,"id":3,"configContract":"TransmissionSettings",` +
+	`"implementation":"Transmission","name":"Transmission","protocol":"torrent","tags":null,"fields":` +
+	`[{"name":"host","value":"transmission"},{"name":"port","value":9091},{"name":"useSSL","value":false}]}`
+
+func TestGetDownloadClients(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, readarr.APIver, "downloadClient"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    "[" + downloadClientResponseBody + "]",
+			WithRequest:     nil,
+			WithResponse: []*readarr.DownloadClientOutput{
+				{
+					Enable:             true,
+					Priority:           1,
+					ID:                 3,
+					ConfigContract:     "TransmissionSettings",
+					Implementation:     "Transmission",
+					ImplementationName: "Transmission",
+					InfoLink:           "https://wiki.servarr.com/readarr/supported#transmission",
+					Name:               "Transmission",
+					Protocol:           "torrent",
+					Fields: []*starr.FieldOutput{
+						{
+							Order:    0,
+							Name:     "host",
+							Label:    "Host",
+							Value:    "transmission",
+							Type:     "textbox",
+							Advanced: false,
+						},
+						{
+							Order:    1,
+							Name:     "port",
+							Label:    "Port",
+							Value:    float64(9091),
+							Type:     "textbox",
+							Advanced: false,
+						},
+						{
+							Order:    2,
+							Name:     "useSsl",
+							Label:    "Use SSL",
+							HelpText: "Use secure connection when connecting to Transmission",
+							Value:    false,
+							Type:     "checkbox",
+							Advanced: false,
+						},
+					},
+					Tags: []int{},
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   ([]*readarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDownloadClients()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, readarr.APIver, "downloadClient", "1"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    downloadClientResponseBody,
+			WithRequest:     nil,
+			WithResponse: &readarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/readarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*readarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDownloadClient(1)
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 200,
+			WithRequest: &readarr.DownloadClientInput{
+				Enable:         true,
+				Priority:       1,
+				ConfigContract: "TransmissionSettings",
+				Implementation: "Transmission",
+				Name:           "Transmission",
+				Protocol:       "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+			},
+			ExpectedRequest: addDownloadClient + "\n",
+			ResponseBody:    downloadClientResponseBody,
+			WithResponse: &readarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/readarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 404,
+			WithRequest: &readarr.DownloadClientInput{
+				Enable:         true,
+				Priority:       1,
+				ConfigContract: "TransmissionSettings",
+				Implementation: "Transmission",
+				Name:           "Transmission",
+				Protocol:       "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+			},
+			ExpectedRequest: addDownloadClient + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*readarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddDownloadClient(test.WithRequest.(*readarr.DownloadClientInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient", "3"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 200,
+			WithRequest: &readarr.DownloadClientInput{
+				Enable:         true,
+				Priority:       1,
+				ConfigContract: "TransmissionSettings",
+				Implementation: "Transmission",
+				Name:           "Transmission",
+				Protocol:       "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+				ID: 3,
+			},
+			ExpectedRequest: updateDownloadClient + "\n",
+			ResponseBody:    downloadClientResponseBody,
+			WithResponse: &readarr.DownloadClientOutput{
+				Enable:             true,
+				Priority:           1,
+				ID:                 3,
+				ConfigContract:     "TransmissionSettings",
+				Implementation:     "Transmission",
+				ImplementationName: "Transmission",
+				InfoLink:           "https://wiki.servarr.com/readarr/supported#transmission",
+				Name:               "Transmission",
+				Protocol:           "torrent",
+				Fields: []*starr.FieldOutput{
+					{
+						Order:    0,
+						Name:     "host",
+						Label:    "Host",
+						Value:    "transmission",
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    1,
+						Name:     "port",
+						Label:    "Port",
+						Value:    float64(9091),
+						Type:     "textbox",
+						Advanced: false,
+					},
+					{
+						Order:    2,
+						Name:     "useSsl",
+						Label:    "Use SSL",
+						HelpText: "Use secure connection when connecting to Transmission",
+						Value:    false,
+						Type:     "checkbox",
+						Advanced: false,
+					},
+				},
+				Tags: []int{},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient", "3"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 404,
+			WithRequest: &readarr.DownloadClientInput{
+				Enable:         true,
+				Priority:       1,
+				ConfigContract: "TransmissionSettings",
+				Implementation: "Transmission",
+				Name:           "Transmission",
+				Protocol:       "torrent",
+				Fields: []*starr.FieldInput{
+					{
+						Name:  "host",
+						Value: "transmission",
+					},
+					{
+						Name:  "port",
+						Value: 9091,
+					},
+					{
+						Name:  "useSSL",
+						Value: false,
+					},
+				},
+				ID: 3,
+			},
+			ExpectedRequest: updateDownloadClient + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*readarr.DownloadClientOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateDownloadClient(test.WithRequest.(*readarr.DownloadClientInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteDownloadClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 200,
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteDownloadClient(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}

--- a/readarr/downloadclientconfig.go
+++ b/readarr/downloadclientconfig.go
@@ -1,0 +1,65 @@
+package readarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for download client config calls.
+const bpDownloadClientConfig = APIver + "/config/downloadClient"
+
+// DownloadClientConfig is the /api/v1/config/downloadClientConfig endpoint.
+type DownloadClientConfig struct {
+	EnableCompletedDownloadHandling bool   `json:"enableCompletedDownloadHandling"`
+	AutoRedownloadFailed            bool   `json:"autoRedownloadFailed"`
+	ID                              int64  `json:"id"`
+	DownloadClientWorkingFolders    string `json:"downloadClientWorkingFolders"`
+	RemoveCompletedDownloads        bool   `json:"removeCompletedDownloads"`
+	RemoveFailedDownloads           bool   `json:"removeFailedDownloads"`
+}
+
+// GetDownloadClientConfig returns the download client config.
+func (r *Readarr) GetDownloadClientConfig() (*DownloadClientConfig, error) {
+	return r.GetDownloadClientConfigContext(context.Background())
+}
+
+// GetDownloadClientConfig returns the download client config.
+func (r *Readarr) GetDownloadClientConfigContext(ctx context.Context) (*DownloadClientConfig, error) {
+	var output DownloadClientConfig
+
+	req := starr.Request{URI: bpDownloadClientConfig}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateDownloadClientConfig update the single download client config.
+func (r *Readarr) UpdateDownloadClientConfig(downloadConfig *DownloadClientConfig) (*DownloadClientConfig, error) {
+	return r.UpdateDownloadClientConfigContext(context.Background(), downloadConfig)
+}
+
+// UpdateDownloadClientConfig update the single download client config.
+func (r *Readarr) UpdateDownloadClientConfigContext(ctx context.Context,
+	config *DownloadClientConfig,
+) (*DownloadClientConfig, error) {
+	var output DownloadClientConfig
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(config); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClientConfig, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpDownloadClientConfig, fmt.Sprint(config.ID)), Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}

--- a/readarr/downloadclientconfig_test.go
+++ b/readarr/downloadclientconfig_test.go
@@ -1,0 +1,130 @@
+package readarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/readarr"
+)
+
+const downloadClientConfigBody = `{
+	"downloadClientWorkingFolders": "_UNPACK_|_FAILED_",
+	"enableCompletedDownloadHandling": true,
+	"removeCompletedDownloads": false,
+	"autoRedownloadFailed": false,
+	"removeFailedDownloads": false,
+	"id": 1
+  }`
+
+const updateDownloadClientConfig = `{"enableCompletedDownloadHandling":true,"autoRedownloadFailed":false,"id":1,` +
+	`"downloadClientWorkingFolders":"_UNPACK_|_FAILED_","removeCompletedDownloads":false,"removeFailedDownloads":false}`
+
+func TestGetDownloadClientConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, readarr.APIver, "config", "downloadClient"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    downloadClientConfigBody,
+			WithRequest:     nil,
+			WithResponse: &readarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling: true,
+				AutoRedownloadFailed:            false,
+				RemoveCompletedDownloads:        false,
+				RemoveFailedDownloads:           false,
+				ID:                              1,
+				DownloadClientWorkingFolders:    "_UNPACK_|_FAILED_",
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "config", "downloadClient"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*readarr.DownloadClientConfig)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetDownloadClientConfig()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateDownloadClientConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "202",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "config", "downloadClient", "1"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 202,
+			WithRequest: &readarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling: true,
+				AutoRedownloadFailed:            false,
+				RemoveCompletedDownloads:        false,
+				RemoveFailedDownloads:           false,
+				ID:                              1,
+				DownloadClientWorkingFolders:    "_UNPACK_|_FAILED_",
+			},
+			ExpectedRequest: updateDownloadClientConfig + "\n",
+			ResponseBody:    downloadClientConfigBody,
+			WithResponse: &readarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling: true,
+				AutoRedownloadFailed:            false,
+				RemoveCompletedDownloads:        false,
+				RemoveFailedDownloads:           false,
+				ID:                              1,
+				DownloadClientWorkingFolders:    "_UNPACK_|_FAILED_",
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "config", "downloadClient", "1"),
+			ExpectedMethod: "PUT",
+			WithRequest: &readarr.DownloadClientConfig{
+				EnableCompletedDownloadHandling: true,
+				AutoRedownloadFailed:            false,
+				RemoveCompletedDownloads:        false,
+				RemoveFailedDownloads:           false,
+				ID:                              1,
+				DownloadClientWorkingFolders:    "_UNPACK_|_FAILED_",
+			},
+			ExpectedRequest: updateDownloadClientConfig + "\n",
+			ResponseStatus:  404,
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*readarr.DownloadClientConfig)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateDownloadClientConfig(test.WithRequest.(*readarr.DownloadClientConfig))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
+		})
+	}
+}

--- a/readarr/remotepathmapping.go
+++ b/readarr/remotepathmapping.go
@@ -13,22 +13,14 @@ import (
 // Define Base Path for remote path mapping calls.
 const bpRemotePathMapping = APIver + "/remotePathMapping"
 
-// RemotePathMapping is the /api/v1/remotePathMapping endpoint.
-type RemotePathMapping struct {
-	ID         int64  `json:"id,omitempty"`
-	Host       string `json:"host"`
-	RemotePath string `json:"remotePath"`
-	LocalPath  string `json:"localPath"`
-}
-
 // GetRemotePathMappings returns all configured remote path mappings.
-func (r *Readarr) GetRemotePathMappings() ([]*RemotePathMapping, error) {
+func (r *Readarr) GetRemotePathMappings() ([]*starr.RemotePathMapping, error) {
 	return r.GetRemotePathMappingsContext(context.Background())
 }
 
 // GetRemotePathMappingsContext returns all configured remote path mappings.
-func (r *Readarr) GetRemotePathMappingsContext(ctx context.Context) ([]*RemotePathMapping, error) {
-	var output []*RemotePathMapping
+func (r *Readarr) GetRemotePathMappingsContext(ctx context.Context) ([]*starr.RemotePathMapping, error) {
+	var output []*starr.RemotePathMapping
 
 	req := starr.Request{URI: bpRemotePathMapping}
 	if err := r.GetInto(ctx, req, &output); err != nil {
@@ -39,13 +31,13 @@ func (r *Readarr) GetRemotePathMappingsContext(ctx context.Context) ([]*RemotePa
 }
 
 // GetRemotePathMapping returns a single remote path mapping.
-func (r *Readarr) GetRemotePathMapping(mappingID int64) (*RemotePathMapping, error) {
+func (r *Readarr) GetRemotePathMapping(mappingID int64) (*starr.RemotePathMapping, error) {
 	return r.GetRemotePathMappingContext(context.Background(), mappingID)
 }
 
 // GetRemotePathMappingContext returns a single remote path mapping.
-func (r *Readarr) GetRemotePathMappingContext(ctx context.Context, mappingID int64) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+func (r *Readarr) GetRemotePathMappingContext(ctx context.Context, mappingID int64) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mappingID))}
 	if err := r.GetInto(ctx, req, &output); err != nil {
@@ -56,15 +48,15 @@ func (r *Readarr) GetRemotePathMappingContext(ctx context.Context, mappingID int
 }
 
 // AddRemotePathMapping creates a remote path mapping.
-func (r *Readarr) AddRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+func (r *Readarr) AddRemotePathMapping(mapping *starr.RemotePathMapping) (*starr.RemotePathMapping, error) {
 	return r.AddRemotePathMappingContext(context.Background(), mapping)
 }
 
 // AddRemotePathMappingContext creates a remote path mapping.
 func (r *Readarr) AddRemotePathMappingContext(ctx context.Context,
-	mapping *RemotePathMapping,
-) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+	mapping *starr.RemotePathMapping,
+) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(mapping); err != nil {
@@ -80,15 +72,15 @@ func (r *Readarr) AddRemotePathMappingContext(ctx context.Context,
 }
 
 // UpdateRemotePathMapping updates the remote path mapping.
-func (r *Readarr) UpdateRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+func (r *Readarr) UpdateRemotePathMapping(mapping *starr.RemotePathMapping) (*starr.RemotePathMapping, error) {
 	return r.UpdateRemotePathMappingContext(context.Background(), mapping)
 }
 
 // UpdateRemotePathMappingContext updates the remote path mapping.
 func (r *Readarr) UpdateRemotePathMappingContext(ctx context.Context,
-	mapping *RemotePathMapping,
-) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+	mapping *starr.RemotePathMapping,
+) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(mapping); err != nil {

--- a/readarr/remotepathmapping.go
+++ b/readarr/remotepathmapping.go
@@ -1,0 +1,119 @@
+package readarr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"golift.io/starr"
+)
+
+// Define Base Path for remote path mapping calls.
+const bpRemotePathMapping = APIver + "/remotePathMapping"
+
+// RemotePathMapping is the /api/v1/remotePathMapping endpoint.
+type RemotePathMapping struct {
+	ID         int64  `json:"id,omitempty"`
+	Host       string `json:"host"`
+	RemotePath string `json:"remotePath"`
+	LocalPath  string `json:"localPath"`
+}
+
+// GetRemotePathMappings returns all configured remote path mappings.
+func (r *Readarr) GetRemotePathMappings() ([]*RemotePathMapping, error) {
+	return r.GetRemotePathMappingsContext(context.Background())
+}
+
+// GetRemotePathMappingsContext returns all configured remote path mappings.
+func (r *Readarr) GetRemotePathMappingsContext(ctx context.Context) ([]*RemotePathMapping, error) {
+	var output []*RemotePathMapping
+
+	req := starr.Request{URI: bpRemotePathMapping}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return output, nil
+}
+
+// GetRemotePathMapping returns a single remote path mapping.
+func (r *Readarr) GetRemotePathMapping(mappingID int64) (*RemotePathMapping, error) {
+	return r.GetRemotePathMappingContext(context.Background(), mappingID)
+}
+
+// GetRemotePathMappingContext returns a single remote path mapping.
+func (r *Readarr) GetRemotePathMappingContext(ctx context.Context, mappingID int64) (*RemotePathMapping, error) {
+	var output RemotePathMapping
+
+	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mappingID))}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// AddRemotePathMapping creates a remote path mapping.
+func (r *Readarr) AddRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+	return r.AddRemotePathMappingContext(context.Background(), mapping)
+}
+
+// AddRemotePathMappingContext creates a remote path mapping.
+func (r *Readarr) AddRemotePathMappingContext(ctx context.Context,
+	mapping *RemotePathMapping,
+) (*RemotePathMapping, error) {
+	var output RemotePathMapping
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(mapping); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpRemotePathMapping, err)
+	}
+
+	req := starr.Request{URI: bpRemotePathMapping, Body: &body}
+	if err := r.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// UpdateRemotePathMapping updates the remote path mapping.
+func (r *Readarr) UpdateRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+	return r.UpdateRemotePathMappingContext(context.Background(), mapping)
+}
+
+// UpdateRemotePathMappingContext updates the remote path mapping.
+func (r *Readarr) UpdateRemotePathMappingContext(ctx context.Context,
+	mapping *RemotePathMapping,
+) (*RemotePathMapping, error) {
+	var output RemotePathMapping
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(mapping); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpRemotePathMapping, err)
+	}
+
+	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mapping.ID)), Body: &body}
+	if err := r.PutInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
+// DeleteRemotePathMapping removes a single remote path mapping.
+func (r *Readarr) DeleteRemotePathMapping(mappingID int64) error {
+	return r.DeleteRemotePathMappingContext(context.Background(), mappingID)
+}
+
+// DeleteRemotePathMappingContext removes a single remote path mapping.
+func (r *Readarr) DeleteRemotePathMappingContext(ctx context.Context, mappingID int64) error {
+	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mappingID))}
+	if err := r.DeleteAny(ctx, req); err != nil {
+		return fmt.Errorf("api.Delete(%s): %w", &req, err)
+	}
+
+	return nil
+}

--- a/readarr/remotepathmapping_test.go
+++ b/readarr/remotepathmapping_test.go
@@ -28,7 +28,7 @@ func TestGetRemotePathMappings(t *testing.T) {
 			ExpectedMethod: "GET",
 			ResponseStatus: 200,
 			ResponseBody:   `[` + remotePathMapping + `]`,
-			WithResponse: []*readarr.RemotePathMapping{
+			WithResponse: []*starr.RemotePathMapping{
 				{
 					Host:       "transmission",
 					RemotePath: "/remote/",
@@ -45,7 +45,7 @@ func TestGetRemotePathMappings(t *testing.T) {
 			ResponseStatus: 404,
 			ResponseBody:   `{"message": "NotFound"}`,
 			WithError:      starr.ErrInvalidStatusCode,
-			WithResponse:   []*readarr.RemotePathMapping(nil),
+			WithResponse:   []*starr.RemotePathMapping(nil),
 		},
 	}
 
@@ -73,7 +73,7 @@ func TestGetRemotePathMapping(t *testing.T) {
 			ResponseStatus: 200,
 			WithRequest:    int64(1),
 			ResponseBody:   remotePathMapping,
-			WithResponse: &readarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -88,7 +88,7 @@ func TestGetRemotePathMapping(t *testing.T) {
 			ResponseStatus: 404,
 			WithRequest:    int64(1),
 			ResponseBody:   `{"message": "NotFound"}`,
-			WithResponse:   (*readarr.RemotePathMapping)(nil),
+			WithResponse:   (*starr.RemotePathMapping)(nil),
 			WithError:      starr.ErrInvalidStatusCode,
 		},
 	}
@@ -115,14 +115,14 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 201,
-			WithRequest: &readarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
 			},
 			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    remotePathMapping,
-			WithResponse: &readarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -135,7 +135,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
-			WithRequest: &readarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -143,7 +143,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    `{"message": "NotFound"}`,
 			WithError:       starr.ErrInvalidStatusCode,
-			WithResponse:    (*readarr.RemotePathMapping)(nil),
+			WithResponse:    (*starr.RemotePathMapping)(nil),
 		},
 	}
 
@@ -153,7 +153,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			t.Parallel()
 			mockServer := test.GetMockServer(t)
 			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
-			output, err := client.AddRemotePathMapping(test.WithRequest.(*readarr.RemotePathMapping))
+			output, err := client.AddRemotePathMapping(test.WithRequest.(*starr.RemotePathMapping))
 			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
@@ -169,7 +169,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping", "2"),
 			ExpectedMethod: "PUT",
 			ResponseStatus: 201,
-			WithRequest: &readarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -177,7 +177,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			},
 			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    remotePathMapping,
-			WithResponse: &readarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -190,7 +190,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping", "2"),
 			ExpectedMethod: "PUT",
 			ResponseStatus: 404,
-			WithRequest: &readarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -199,7 +199,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    `{"message": "NotFound"}`,
 			WithError:       starr.ErrInvalidStatusCode,
-			WithResponse:    (*readarr.RemotePathMapping)(nil),
+			WithResponse:    (*starr.RemotePathMapping)(nil),
 		},
 	}
 
@@ -209,7 +209,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			t.Parallel()
 			mockServer := test.GetMockServer(t)
 			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
-			output, err := client.UpdateRemotePathMapping(test.WithRequest.(*readarr.RemotePathMapping))
+			output, err := client.UpdateRemotePathMapping(test.WithRequest.(*starr.RemotePathMapping))
 			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})

--- a/readarr/remotepathmapping_test.go
+++ b/readarr/remotepathmapping_test.go
@@ -1,0 +1,253 @@
+package readarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/readarr"
+)
+
+const (
+	remotePathMapping = `{
+		"host": "transmission",
+		"remotePath": "/remote/",
+		"localPath": "/local/",
+		"id": 2
+	}`
+)
+
+func TestGetRemotePathMappings(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			ResponseBody:   `[` + remotePathMapping + `]`,
+			WithResponse: []*readarr.RemotePathMapping{
+				{
+					Host:       "transmission",
+					RemotePath: "/remote/",
+					LocalPath:  "/local/",
+					ID:         2,
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   []*readarr.RemotePathMapping(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetRemotePathMappings()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 200,
+			WithRequest:    int64(1),
+			ResponseBody:   remotePathMapping,
+			WithResponse: &readarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			WithRequest:    int64(1),
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithResponse:   (*readarr.RemotePathMapping)(nil),
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetRemotePathMapping(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "201",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 201,
+			WithRequest: &readarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+			},
+			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    remotePathMapping,
+			WithResponse: &readarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 404,
+			WithRequest: &readarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+			},
+			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*readarr.RemotePathMapping)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddRemotePathMapping(test.WithRequest.(*readarr.RemotePathMapping))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "201",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 201,
+			WithRequest: &readarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    remotePathMapping,
+			WithResponse: &readarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 404,
+			WithRequest: &readarr.RemotePathMapping{
+				Host:       "transmission",
+				RemotePath: "/remote/",
+				LocalPath:  "/local/",
+				ID:         2,
+			},
+			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*readarr.RemotePathMapping)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateRemotePathMapping(test.WithRequest.(*readarr.RemotePathMapping))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteRemotePathMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 200,
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "remotePathMapping", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := readarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteRemotePathMapping(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}

--- a/shared.go
+++ b/shared.go
@@ -139,6 +139,14 @@ type Path struct {
 	Path string `json:"path"`
 }
 
+// RemotePathMapping is the remotePathMapping endpoint.
+type RemotePathMapping struct {
+	ID         int64  `json:"id,omitempty"`
+	Host       string `json:"host"`
+	RemotePath string `json:"remotePath"`
+	LocalPath  string `json:"localPath"`
+}
+
 // Value is generic ID/Name struct applied to a few places.
 type Value struct {
 	ID   int64  `json:"id"`

--- a/sonarr/remotepathmapping.go
+++ b/sonarr/remotepathmapping.go
@@ -13,22 +13,14 @@ import (
 // Define Base Path for remote path mapping calls.
 const bpRemotePathMapping = APIver + "/remotePathMapping"
 
-// RemotePathMapping is the /api/v3/remotePathMapping endpoint.
-type RemotePathMapping struct {
-	ID         int64  `json:"id,omitempty"`
-	Host       string `json:"host"`
-	RemotePath string `json:"remotePath"`
-	LocalPath  string `json:"localPath"`
-}
-
 // GetRemotePathMappings returns all configured remote path mappings.
-func (s *Sonarr) GetRemotePathMappings() ([]*RemotePathMapping, error) {
+func (s *Sonarr) GetRemotePathMappings() ([]*starr.RemotePathMapping, error) {
 	return s.GetRemotePathMappingsContext(context.Background())
 }
 
 // GetRemotePathMappingsContext returns all configured remote path mappings.
-func (s *Sonarr) GetRemotePathMappingsContext(ctx context.Context) ([]*RemotePathMapping, error) {
-	var output []*RemotePathMapping
+func (s *Sonarr) GetRemotePathMappingsContext(ctx context.Context) ([]*starr.RemotePathMapping, error) {
+	var output []*starr.RemotePathMapping
 
 	req := starr.Request{URI: bpRemotePathMapping}
 	if err := s.GetInto(ctx, req, &output); err != nil {
@@ -39,13 +31,13 @@ func (s *Sonarr) GetRemotePathMappingsContext(ctx context.Context) ([]*RemotePat
 }
 
 // GetRemotePathMapping returns a single remote path mapping.
-func (s *Sonarr) GetRemotePathMapping(mappingID int64) (*RemotePathMapping, error) {
+func (s *Sonarr) GetRemotePathMapping(mappingID int64) (*starr.RemotePathMapping, error) {
 	return s.GetRemotePathMappingContext(context.Background(), mappingID)
 }
 
 // GetRemotePathMappingContext returns a single remote path mapping.
-func (s *Sonarr) GetRemotePathMappingContext(ctx context.Context, mappingID int64) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+func (s *Sonarr) GetRemotePathMappingContext(ctx context.Context, mappingID int64) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	req := starr.Request{URI: path.Join(bpRemotePathMapping, fmt.Sprint(mappingID))}
 	if err := s.GetInto(ctx, req, &output); err != nil {
@@ -56,15 +48,15 @@ func (s *Sonarr) GetRemotePathMappingContext(ctx context.Context, mappingID int6
 }
 
 // AddRemotePathMapping creates a remote path mapping.
-func (s *Sonarr) AddRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+func (s *Sonarr) AddRemotePathMapping(mapping *starr.RemotePathMapping) (*starr.RemotePathMapping, error) {
 	return s.AddRemotePathMappingContext(context.Background(), mapping)
 }
 
 // AddRemotePathMappingContext creates a remote path mapping.
 func (s *Sonarr) AddRemotePathMappingContext(ctx context.Context,
-	mapping *RemotePathMapping,
-) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+	mapping *starr.RemotePathMapping,
+) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(mapping); err != nil {
@@ -80,15 +72,15 @@ func (s *Sonarr) AddRemotePathMappingContext(ctx context.Context,
 }
 
 // UpdateRemotePathMapping updates the remote path mapping.
-func (s *Sonarr) UpdateRemotePathMapping(mapping *RemotePathMapping) (*RemotePathMapping, error) {
+func (s *Sonarr) UpdateRemotePathMapping(mapping *starr.RemotePathMapping) (*starr.RemotePathMapping, error) {
 	return s.UpdateRemotePathMappingContext(context.Background(), mapping)
 }
 
 // UpdateRemotePathMappingContext updates the remote path mapping.
 func (s *Sonarr) UpdateRemotePathMappingContext(ctx context.Context,
-	mapping *RemotePathMapping,
-) (*RemotePathMapping, error) {
-	var output RemotePathMapping
+	mapping *starr.RemotePathMapping,
+) (*starr.RemotePathMapping, error) {
+	var output starr.RemotePathMapping
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(mapping); err != nil {

--- a/sonarr/remotepathmapping_test.go
+++ b/sonarr/remotepathmapping_test.go
@@ -28,7 +28,7 @@ func TestGetRemotePathMappings(t *testing.T) {
 			ExpectedMethod: "GET",
 			ResponseStatus: 200,
 			ResponseBody:   `[` + remotePathMapping + `]`,
-			WithResponse: []*sonarr.RemotePathMapping{
+			WithResponse: []*starr.RemotePathMapping{
 				{
 					Host:       "transmission",
 					RemotePath: "/remote/",
@@ -45,7 +45,7 @@ func TestGetRemotePathMappings(t *testing.T) {
 			ResponseStatus: 404,
 			ResponseBody:   `{"message": "NotFound"}`,
 			WithError:      starr.ErrInvalidStatusCode,
-			WithResponse:   []*sonarr.RemotePathMapping(nil),
+			WithResponse:   []*starr.RemotePathMapping(nil),
 		},
 	}
 
@@ -73,7 +73,7 @@ func TestGetRemotePathMapping(t *testing.T) {
 			ResponseStatus: 200,
 			WithRequest:    int64(1),
 			ResponseBody:   remotePathMapping,
-			WithResponse: &sonarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -88,7 +88,7 @@ func TestGetRemotePathMapping(t *testing.T) {
 			ResponseStatus: 404,
 			WithRequest:    int64(1),
 			ResponseBody:   `{"message": "NotFound"}`,
-			WithResponse:   (*sonarr.RemotePathMapping)(nil),
+			WithResponse:   (*starr.RemotePathMapping)(nil),
 			WithError:      starr.ErrInvalidStatusCode,
 		},
 	}
@@ -115,14 +115,14 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "remotePathMapping"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 201,
-			WithRequest: &sonarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
 			},
 			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    remotePathMapping,
-			WithResponse: &sonarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -135,7 +135,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "remotePathMapping"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
-			WithRequest: &sonarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -143,7 +143,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			ExpectedRequest: `{"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    `{"message": "NotFound"}`,
 			WithError:       starr.ErrInvalidStatusCode,
-			WithResponse:    (*sonarr.RemotePathMapping)(nil),
+			WithResponse:    (*starr.RemotePathMapping)(nil),
 		},
 	}
 
@@ -153,7 +153,7 @@ func TestAddRemotePathMapping(t *testing.T) {
 			t.Parallel()
 			mockServer := test.GetMockServer(t)
 			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
-			output, err := client.AddRemotePathMapping(test.WithRequest.(*sonarr.RemotePathMapping))
+			output, err := client.AddRemotePathMapping(test.WithRequest.(*starr.RemotePathMapping))
 			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
@@ -169,7 +169,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "remotePathMapping", "2"),
 			ExpectedMethod: "PUT",
 			ResponseStatus: 201,
-			WithRequest: &sonarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -177,7 +177,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			},
 			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    remotePathMapping,
-			WithResponse: &sonarr.RemotePathMapping{
+			WithResponse: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -190,7 +190,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "remotePathMapping", "2"),
 			ExpectedMethod: "PUT",
 			ResponseStatus: 404,
-			WithRequest: &sonarr.RemotePathMapping{
+			WithRequest: &starr.RemotePathMapping{
 				Host:       "transmission",
 				RemotePath: "/remote/",
 				LocalPath:  "/local/",
@@ -199,7 +199,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			ExpectedRequest: `{"id":2,"host":"transmission","remotePath":"/remote/","localPath":"/local/"}` + "\n",
 			ResponseBody:    `{"message": "NotFound"}`,
 			WithError:       starr.ErrInvalidStatusCode,
-			WithResponse:    (*sonarr.RemotePathMapping)(nil),
+			WithResponse:    (*starr.RemotePathMapping)(nil),
 		},
 	}
 
@@ -209,7 +209,7 @@ func TestUpdateRemotePathMapping(t *testing.T) {
 			t.Parallel()
 			mockServer := test.GetMockServer(t)
 			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
-			output, err := client.UpdateRemotePathMapping(test.WithRequest.(*sonarr.RemotePathMapping))
+			output, err := client.UpdateRemotePathMapping(test.WithRequest.(*starr.RemotePathMapping))
 			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})


### PR DESCRIPTION
- add downloadclientconfig (radarr,readarr,lidarr)
- add remotepathmapping (radarr,readarr,lidarr)
- add downloadclient (radarr,readarr,lidarr,prowlarr)

Since remotepathmapping is the same in each arr, we can put the struct definition in the starr package. @davidnewhall what do you think? should we keep each file separate, or should we group the struct definition in one place?

the other 2 resources change a bit between different arr