### PR TITLE
feat(radarr)!: update customformat methods

### DIFF
--- a/radarr/customformat.go
+++ b/radarr/customformat.go
@@ -12,43 +12,50 @@ import (
 
 const bpCustomFormat = APIver + "/customFormat"
 
-// CustomFormat is the api/customformat endpoint payload.
-type CustomFormat struct {
-	ID                    int                 `json:"id"`
-	Name                  string              `json:"name"`
-	IncludeCFWhenRenaming bool                `json:"includeCustomFormatWhenRenaming"`
-	Specifications        []*CustomFormatSpec `json:"specifications"`
+// CustomFormatInput is the input for a new or updated CustomFormat.
+type CustomFormatInput struct {
+	ID                    int64                    `json:"id,omitempty"`
+	Name                  string                   `json:"name"`
+	IncludeCFWhenRenaming bool                     `json:"includeCustomFormatWhenRenaming"`
+	Specifications        []*CustomFormatInputSpec `json:"specifications"`
 }
 
-// CustomFormatSpec is part of a CustomFormat.
-type CustomFormatSpec struct {
+// CustomFormatInputSpec is part of a CustomFormatInput.
+type CustomFormatInputSpec struct {
+	Name           string              `json:"name"`
+	Implementation string              `json:"implementation"`
+	Negate         bool                `json:"negate"`
+	Required       bool                `json:"required"`
+	Fields         []*starr.FieldInput `json:"fields"`
+}
+
+// CustomFormatOutput is the output from the CustomFormat methods.
+type CustomFormatOutput struct {
+	ID                    int64                     `json:"id"`
+	Name                  string                    `json:"name"`
+	IncludeCFWhenRenaming bool                      `json:"includeCustomFormatWhenRenaming"`
+	Specifications        []*CustomFormatOutputSpec `json:"specifications"`
+}
+
+// CustomFormatOutputSpec is part of a CustomFormatOutput.
+type CustomFormatOutputSpec struct {
 	Name               string               `json:"name"`
 	Implementation     string               `json:"implementation"`
-	Implementationname string               `json:"implementationName"`
-	Infolink           string               `json:"infoLink"`
+	ImplementationName string               `json:"implementationName"`
+	InfoLink           string               `json:"infoLink"`
 	Negate             bool                 `json:"negate"`
 	Required           bool                 `json:"required"`
-	Fields             []*CustomFormatField `json:"fields"`
-}
-
-// CustomFormatField is part of a CustomFormat Specification.
-type CustomFormatField struct {
-	Order    int         `json:"order"`
-	Name     string      `json:"name"`
-	Label    string      `json:"label"`
-	Value    interface{} `json:"value"` // should be a string, but sometimes it's a number.
-	Type     string      `json:"type"`
-	Advanced bool        `json:"advanced"`
+	Fields             []*starr.FieldOutput `json:"fields"`
 }
 
 // GetCustomFormats returns all configured Custom Formats.
-func (r *Radarr) GetCustomFormats() ([]*CustomFormat, error) {
+func (r *Radarr) GetCustomFormats() ([]*CustomFormatOutput, error) {
 	return r.GetCustomFormatsContext(context.Background())
 }
 
 // GetCustomFormatsContext returns all configured Custom Formats.
-func (r *Radarr) GetCustomFormatsContext(ctx context.Context) ([]*CustomFormat, error) {
-	var output []*CustomFormat
+func (r *Radarr) GetCustomFormatsContext(ctx context.Context) ([]*CustomFormatOutput, error) {
+	var output []*CustomFormatOutput
 
 	req := starr.Request{URI: bpCustomFormat}
 	if err := r.GetInto(ctx, req, &output); err != nil {
@@ -58,20 +65,31 @@ func (r *Radarr) GetCustomFormatsContext(ctx context.Context) ([]*CustomFormat, 
 	return output, nil
 }
 
+// GetCustomFormat returns a single customformat.
+func (r *Radarr) GetCustomFormat(customformatID int64) (*CustomFormatOutput, error) {
+	return r.GetCustomFormatContext(context.Background(), customformatID)
+}
+
+// GetCustomFormatContext returns a single customformat.
+func (r *Radarr) GetCustomFormatContext(ctx context.Context, customformatID int64) (*CustomFormatOutput, error) {
+	var output CustomFormatOutput
+
+	req := starr.Request{URI: path.Join(bpCustomFormat, fmt.Sprint(customformatID))}
+	if err := r.GetInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Get(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}
+
 // AddCustomFormat creates a new custom format and returns the response (with ID).
-func (r *Radarr) AddCustomFormat(format *CustomFormat) (*CustomFormat, error) {
+func (r *Radarr) AddCustomFormat(format *CustomFormatInput) (*CustomFormatOutput, error) {
 	return r.AddCustomFormatContext(context.Background(), format)
 }
 
 // AddCustomFormatContext creates a new custom format and returns the response (with ID).
-func (r *Radarr) AddCustomFormatContext(ctx context.Context, format *CustomFormat) (*CustomFormat, error) {
-	var output CustomFormat
-
-	if format == nil {
-		return &output, nil
-	}
-
-	format.ID = 0 // ID must be zero when adding.
+func (r *Radarr) AddCustomFormatContext(ctx context.Context, format *CustomFormatInput) (*CustomFormatOutput, error) {
+	var output CustomFormatOutput
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(format); err != nil {
@@ -87,24 +105,22 @@ func (r *Radarr) AddCustomFormatContext(ctx context.Context, format *CustomForma
 }
 
 // UpdateCustomFormat updates an existing custom format and returns the response.
-func (r *Radarr) UpdateCustomFormat(cf *CustomFormat, cfID int) (*CustomFormat, error) {
-	return r.UpdateCustomFormatContext(context.Background(), cf, cfID)
+func (r *Radarr) UpdateCustomFormat(cf *CustomFormatInput) (*CustomFormatOutput, error) {
+	return r.UpdateCustomFormatContext(context.Background(), cf)
 }
 
 // UpdateCustomFormatContext updates an existing custom format and returns the response.
-func (r *Radarr) UpdateCustomFormatContext(ctx context.Context, format *CustomFormat, cfID int) (*CustomFormat, error) {
-	if cfID == 0 {
-		cfID = format.ID
-	}
+func (r *Radarr) UpdateCustomFormatContext(ctx context.Context,
+	format *CustomFormatInput,
+) (*CustomFormatOutput, error) {
+	var output CustomFormatOutput
 
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(format); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpCustomFormat, err)
 	}
 
-	var output CustomFormat
-
-	req := starr.Request{URI: path.Join(bpCustomFormat, fmt.Sprint(cfID)), Body: &body}
+	req := starr.Request{URI: path.Join(bpCustomFormat, fmt.Sprint(format.ID)), Body: &body}
 	if err := r.PutInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Put(%s): %w", &req, err)
 	}
@@ -113,12 +129,12 @@ func (r *Radarr) UpdateCustomFormatContext(ctx context.Context, format *CustomFo
 }
 
 // DeleteCustomFormat deletes a custom format.
-func (r *Radarr) DeleteCustomFormat(cfID int) error {
+func (r *Radarr) DeleteCustomFormat(cfID int64) error {
 	return r.DeleteCustomFormatContext(context.Background(), cfID)
 }
 
 // DeleteCustomFormatContext deletes a custom format.
-func (r *Radarr) DeleteCustomFormatContext(ctx context.Context, cfID int) error {
+func (r *Radarr) DeleteCustomFormatContext(ctx context.Context, cfID int64) error {
 	req := starr.Request{URI: path.Join(bpCustomFormat, fmt.Sprint(cfID))}
 	if err := r.DeleteAny(ctx, req); err != nil {
 		return fmt.Errorf("api.Delete(%s): %w", &req, err)

--- a/radarr/customformat_test.go
+++ b/radarr/customformat_test.go
@@ -1,0 +1,627 @@
+package radarr_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golift.io/starr"
+	"golift.io/starr/radarr"
+)
+
+const customFormatResponseBody = `{
+    "id": 1,
+    "name": "test",
+    "includeCustomFormatWhenRenaming": false,
+    "specifications": [
+        {
+            "name": "Surround Sound",
+            "implementation": "ReleaseTitleSpecification",
+            "implementationName": "Release Title",
+            "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+            "negate": false,
+            "required": false,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Regular Expression",
+                    "helpText": "Custom Format RegEx is Case Insensitive",
+                    "value": "DTS.?(HD|ES|X(?!\\D))|TRUEHD|ATMOS|DD(\\+|P).?([5-9])|EAC3.?([5-9])",
+                    "type": "textbox",
+                    "advanced": false
+                }
+            ]
+        },
+        {
+            "name": "Arabic",
+            "implementation": "LanguageSpecification",
+            "implementationName": "Language",
+            "infoLink": "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+            "negate": false,
+            "required": false,
+            "fields": [
+                {
+                    "order": 0,
+                    "name": "value",
+                    "label": "Language",
+                    "value": 31,
+                    "type": "select",
+                    "advanced": false,
+                    "selectOptions": [
+                        {
+                            "value": 0,
+                            "name": "Unknown",
+                            "order": 0,
+                            "dividerAfter": true
+                        },
+                        {
+                            "value": 31,
+                            "name": "Arabic",
+                            "order": 0,
+                            "dividerAfter": false
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}`
+
+const addCustomFormat = `{"name":"test","includeCustomFormatWhenRenaming":false,"specifications":` +
+	`[{"name":"Surround Sound","implementation":"ReleaseTitleSpecification","negate":false,"required":false,"fields":` +
+	`[{"name":"value","value":"DTS.?(HD|ES|X(?!\\D))|TRUEHD|ATMOS|DD(\\+|P).?([5-9])|EAC3.?([5-9])"}]},{"name":"Arabic",` +
+	`"implementation":"LanguageSpecification","negate":false,"required":false,"fields":[{"name":"value","value":31}]}]}`
+
+const updateCustomFormat = `{"id":1,"name":"test","includeCustomFormatWhenRenaming":false,"specifications":` +
+	`[{"name":"Surround Sound","implementation":"ReleaseTitleSpecification","negate":false,"required":false,"fields":` +
+	`[{"name":"value","value":"DTS.?(HD|ES|X(?!\\D))|TRUEHD|ATMOS|DD(\\+|P).?([5-9])|EAC3.?([5-9])"}]},{"name":"Arabic",` +
+	`"implementation":"LanguageSpecification","negate":false,"required":false,"fields":[{"name":"value","value":31}]}]}`
+
+func TestGetCustomFormats(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, radarr.APIver, "customFormat"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    "[" + customFormatResponseBody + "]",
+			WithRequest:     nil,
+			WithResponse: []*radarr.CustomFormatOutput{
+				{
+					ID:                    1,
+					Name:                  "test",
+					IncludeCFWhenRenaming: false,
+					Specifications: []*radarr.CustomFormatOutputSpec{
+						{
+							Name:               "Surround Sound",
+							Implementation:     "ReleaseTitleSpecification",
+							ImplementationName: "Release Title",
+							InfoLink:           "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+							Negate:             false,
+							Required:           false,
+							Fields: []*starr.FieldOutput{
+								{
+									Order:    0,
+									Name:     "value",
+									Label:    "Regular Expression",
+									HelpText: "Custom Format RegEx is Case Insensitive",
+									Value:    "DTS.?(HD|ES|X(?!\\D))|TRUEHD|ATMOS|DD(\\+|P).?([5-9])|EAC3.?([5-9])",
+									Type:     "textbox",
+									Advanced: false,
+								},
+							},
+						},
+						{
+							Name:               "Arabic",
+							Implementation:     "LanguageSpecification",
+							ImplementationName: "Language",
+							InfoLink:           "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+							Negate:             false,
+							Required:           false,
+							Fields: []*starr.FieldOutput{
+								{
+									Order: 0,
+									Name:  "value",
+									Label: "Language",
+									// float because of unmarshal.
+									Value:    float64(31),
+									Type:     "select",
+									Advanced: false,
+									SelectOptions: []*starr.SelectOption{
+										{
+											Value:        0,
+											Name:         "Unknown",
+											Order:        0,
+											DividerAfter: true,
+										},
+										{
+											Value:        31,
+											Name:         "Arabic",
+											Order:        0,
+											DividerAfter: false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "customFormat"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   ([]*radarr.CustomFormatOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetCustomFormats()
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestGetCustomFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:            "200",
+			ExpectedPath:    path.Join("/", starr.API, radarr.APIver, "customFormat", "1"),
+			ExpectedRequest: "",
+			ExpectedMethod:  "GET",
+			ResponseStatus:  200,
+			ResponseBody:    customFormatResponseBody,
+			WithRequest:     nil,
+			WithResponse: &radarr.CustomFormatOutput{
+				ID:                    1,
+				Name:                  "test",
+				IncludeCFWhenRenaming: false,
+				Specifications: []*radarr.CustomFormatOutputSpec{
+					{
+						Name:               "Surround Sound",
+						Implementation:     "ReleaseTitleSpecification",
+						ImplementationName: "Release Title",
+						InfoLink:           "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+						Negate:             false,
+						Required:           false,
+						Fields: []*starr.FieldOutput{
+							{
+								Order:    0,
+								Name:     "value",
+								Label:    "Regular Expression",
+								HelpText: "Custom Format RegEx is Case Insensitive",
+								Value:    "DTS.?(HD|ES|X(?!\\D))|TRUEHD|ATMOS|DD(\\+|P).?([5-9])|EAC3.?([5-9])",
+								Type:     "textbox",
+								Advanced: false,
+							},
+						},
+					},
+					{
+						Name:               "Arabic",
+						Implementation:     "LanguageSpecification",
+						ImplementationName: "Language",
+						InfoLink:           "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+						Negate:             false,
+						Required:           false,
+						Fields: []*starr.FieldOutput{
+							{
+								Order: 0,
+								Name:  "value",
+								Label: "Language",
+								// float because of unmarshal.
+								Value:    float64(31),
+								Type:     "select",
+								Advanced: false,
+								SelectOptions: []*starr.SelectOption{
+									{
+										Value:        0,
+										Name:         "Unknown",
+										Order:        0,
+										DividerAfter: true,
+									},
+									{
+										Value:        31,
+										Name:         "Arabic",
+										Order:        0,
+										DividerAfter: false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "customFormat", "1"),
+			ExpectedMethod: "GET",
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+			WithResponse:   (*radarr.CustomFormatOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.GetCustomFormat(1)
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestAddCustomFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "customFormat"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 200,
+			WithRequest: &radarr.CustomFormatInput{
+				IncludeCFWhenRenaming: false,
+				Name:                  "test",
+				Specifications: []*radarr.CustomFormatInputSpec{
+					{
+						Name:           "Surround Sound",
+						Implementation: "ReleaseTitleSpecification",
+						Negate:         false,
+						Required:       false,
+						Fields: []*starr.FieldInput{
+							{
+								Name:  "value",
+								Value: "DTS.?(HD|ES|X(?!\\D))|TRUEHD|ATMOS|DD(\\+|P).?([5-9])|EAC3.?([5-9])",
+							},
+						},
+					},
+					{
+						Implementation: "LanguageSpecification",
+						Negate:         false,
+						Required:       false,
+						Fields: []*starr.FieldInput{
+							{
+								Name:  "value",
+								Value: 31,
+							},
+						},
+						Name: "Arabic",
+					},
+				},
+			},
+			ExpectedRequest: addCustomFormat + "\n",
+			ResponseBody:    customFormatResponseBody,
+			WithResponse: &radarr.CustomFormatOutput{
+				ID:                    1,
+				Name:                  "test",
+				IncludeCFWhenRenaming: false,
+				Specifications: []*radarr.CustomFormatOutputSpec{
+					{
+						Name:               "Surround Sound",
+						Implementation:     "ReleaseTitleSpecification",
+						ImplementationName: "Release Title",
+						InfoLink:           "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+						Negate:             false,
+						Required:           false,
+						Fields: []*starr.FieldOutput{
+							{
+								Order:    0,
+								Name:     "value",
+								Label:    "Regular Expression",
+								HelpText: "Custom Format RegEx is Case Insensitive",
+								Value:    "DTS.?(HD|ES|X(?!\\D))|TRUEHD|ATMOS|DD(\\+|P).?([5-9])|EAC3.?([5-9])",
+								Type:     "textbox",
+								Advanced: false,
+							},
+						},
+					},
+					{
+						Name:               "Arabic",
+						Implementation:     "LanguageSpecification",
+						ImplementationName: "Language",
+						InfoLink:           "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+						Negate:             false,
+						Required:           false,
+						Fields: []*starr.FieldOutput{
+							{
+								Order: 0,
+								Name:  "value",
+								Label: "Language",
+								// float because of unmarshal.
+								Value:    float64(31),
+								Type:     "select",
+								Advanced: false,
+								SelectOptions: []*starr.SelectOption{
+									{
+										Value:        0,
+										Name:         "Unknown",
+										Order:        0,
+										DividerAfter: true,
+									},
+									{
+										Value:        31,
+										Name:         "Arabic",
+										Order:        0,
+										DividerAfter: false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "customFormat"),
+			ExpectedMethod: "POST",
+			ResponseStatus: 404,
+			WithRequest: &radarr.CustomFormatInput{
+				IncludeCFWhenRenaming: false,
+				Name:                  "test",
+				Specifications: []*radarr.CustomFormatInputSpec{
+					{
+						Name:           "Surround Sound",
+						Implementation: "ReleaseTitleSpecification",
+						Negate:         false,
+						Required:       false,
+						Fields: []*starr.FieldInput{
+							{
+								Name:  "value",
+								Value: "DTS.?(HD|ES|X(?!\\D))|TRUEHD|ATMOS|DD(\\+|P).?([5-9])|EAC3.?([5-9])",
+							},
+						},
+					},
+					{
+						Implementation: "LanguageSpecification",
+						Negate:         false,
+						Required:       false,
+						Fields: []*starr.FieldInput{
+							{
+								Name:  "value",
+								Value: 31,
+							},
+						},
+						Name: "Arabic",
+					},
+				},
+			},
+			ExpectedRequest: addCustomFormat + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.CustomFormatOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.AddCustomFormat(test.WithRequest.(*radarr.CustomFormatInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestUpdateCustomFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "customFormat", "1"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 200,
+			WithRequest: &radarr.CustomFormatInput{
+				ID:                    1,
+				IncludeCFWhenRenaming: false,
+				Name:                  "test",
+				Specifications: []*radarr.CustomFormatInputSpec{
+					{
+						Name:           "Surround Sound",
+						Implementation: "ReleaseTitleSpecification",
+						Negate:         false,
+						Required:       false,
+						Fields: []*starr.FieldInput{
+							{
+								Name:  "value",
+								Value: "DTS.?(HD|ES|X(?!\\D))|TRUEHD|ATMOS|DD(\\+|P).?([5-9])|EAC3.?([5-9])",
+							},
+						},
+					},
+					{
+						Implementation: "LanguageSpecification",
+						Negate:         false,
+						Required:       false,
+						Fields: []*starr.FieldInput{
+							{
+								Name:  "value",
+								Value: 31,
+							},
+						},
+						Name: "Arabic",
+					},
+				},
+			},
+			ExpectedRequest: updateCustomFormat + "\n",
+			ResponseBody:    customFormatResponseBody,
+			WithResponse: &radarr.CustomFormatOutput{
+				ID:                    1,
+				Name:                  "test",
+				IncludeCFWhenRenaming: false,
+				Specifications: []*radarr.CustomFormatOutputSpec{
+					{
+						Name:               "Surround Sound",
+						Implementation:     "ReleaseTitleSpecification",
+						ImplementationName: "Release Title",
+						InfoLink:           "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+						Negate:             false,
+						Required:           false,
+						Fields: []*starr.FieldOutput{
+							{
+								Order:    0,
+								Name:     "value",
+								Label:    "Regular Expression",
+								HelpText: "Custom Format RegEx is Case Insensitive",
+								Value:    "DTS.?(HD|ES|X(?!\\D))|TRUEHD|ATMOS|DD(\\+|P).?([5-9])|EAC3.?([5-9])",
+								Type:     "textbox",
+								Advanced: false,
+							},
+						},
+					},
+					{
+						Name:               "Arabic",
+						Implementation:     "LanguageSpecification",
+						ImplementationName: "Language",
+						InfoLink:           "https://wiki.servarr.com/radarr/settings#custom-formats-2",
+						Negate:             false,
+						Required:           false,
+						Fields: []*starr.FieldOutput{
+							{
+								Order: 0,
+								Name:  "value",
+								Label: "Language",
+								// float because of unmarshal.
+								Value:    float64(31),
+								Type:     "select",
+								Advanced: false,
+								SelectOptions: []*starr.SelectOption{
+									{
+										Value:        0,
+										Name:         "Unknown",
+										Order:        0,
+										DividerAfter: true,
+									},
+									{
+										Value:        31,
+										Name:         "Arabic",
+										Order:        0,
+										DividerAfter: false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			WithError: nil,
+		},
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "customFormat", "1"),
+			ExpectedMethod: "PUT",
+			ResponseStatus: 404,
+			WithRequest: &radarr.CustomFormatInput{
+				ID:                    1,
+				IncludeCFWhenRenaming: false,
+				Name:                  "test",
+				Specifications: []*radarr.CustomFormatInputSpec{
+					{
+						Name:           "Surround Sound",
+						Implementation: "ReleaseTitleSpecification",
+						Negate:         false,
+						Required:       false,
+						Fields: []*starr.FieldInput{
+							{
+								Name:  "value",
+								Value: "DTS.?(HD|ES|X(?!\\D))|TRUEHD|ATMOS|DD(\\+|P).?([5-9])|EAC3.?([5-9])",
+							},
+						},
+					},
+					{
+						Implementation: "LanguageSpecification",
+						Negate:         false,
+						Required:       false,
+						Fields: []*starr.FieldInput{
+							{
+								Name:  "value",
+								Value: 31,
+							},
+						},
+						Name: "Arabic",
+					},
+				},
+			},
+			ExpectedRequest: updateCustomFormat + "\n",
+			ResponseBody:    `{"message": "NotFound"}`,
+			WithError:       starr.ErrInvalidStatusCode,
+			WithResponse:    (*radarr.CustomFormatOutput)(nil),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			output, err := client.UpdateCustomFormat(test.WithRequest.(*radarr.CustomFormatInput))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
+		})
+	}
+}
+
+func TestDeleteCustomFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []*starr.TestMockData{
+		{
+			Name:           "200",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "customFormat", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 200,
+			ResponseBody:   "{}",
+			WithError:      nil,
+		},
+		{
+			Name:           "404",
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "customFormat", "2"),
+			ExpectedMethod: "DELETE",
+			WithRequest:    int64(2),
+			ResponseStatus: 404,
+			ResponseBody:   `{"message": "NotFound"}`,
+			WithError:      starr.ErrInvalidStatusCode,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+			mockServer := test.GetMockServer(t)
+			client := radarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
+			err := client.DeleteCustomFormat(test.WithRequest.(int64))
+			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+		})
+	}
+}

--- a/shared.go
+++ b/shared.go
@@ -176,10 +176,11 @@ type FieldInput struct {
 
 // SelectOption is part of Field.
 type SelectOption struct {
-	Order int64  `json:"order"`
-	Value int64  `json:"value"`
-	Hint  string `json:"hint"`
-	Name  string `json:"name"`
+	DividerAfter bool   `json:"dividerAfter,omitempty"`
+	Order        int64  `json:"order"`
+	Value        int64  `json:"value"`
+	Hint         string `json:"hint"`
+	Name         string `json:"name"`
 }
 
 // KeyValue is yet another reusable generic type.


### PR DESCRIPTION
per #84, here is the PR. Main changes are:
- `CustomFormat` struct has been split into `CustomFormatInput` and `CustomFormatOutput`
- `CustomFormatSpec` has been split into `CustomFormatInputSpec` and `CustomFormatOutputSpec`. One of the main point here is that input won't contain `ImplementationName` and `InfoLink` anymore
- `CustomFormatField` has been removed in favor of `starr.FieldInput` and `starr.FieldOutput`. Which is the other main point of the previous one
- `ID` field changed type from `int` to `int64`
- `ImplementationName` and `InfoLink` fields to PascalCase
- `UpdateCustomFormat` takes the `ID` directly from `CustomFormatInput`. On this one, I don't know if there is any use case in which the two inputs would actually differ.
- added `GetCustomFormat` method

Thoughts?