### PR TITLE
preserve client transport in debug log

### DIFF
--- a/shared.go
+++ b/shared.go
@@ -55,7 +55,7 @@ func Client(timeout time.Duration, verifySSL bool) *http.Client {
 // ClientWithDebug returns an http client with a debug logger enabled.
 func ClientWithDebug(timeout time.Duration, verifySSL bool, logConfig debuglog.Config) *http.Client {
 	client := Client(timeout, verifySSL)
-	client.Transport = debuglog.NewLoggingRoundTripper(logConfig, nil)
+	client.Transport = debuglog.NewLoggingRoundTripper(logConfig, client.Transport)
 
 	return client
 }

--- a/sonarr/episode_test.go
+++ b/sonarr/episode_test.go
@@ -30,7 +30,7 @@ const (
 			"path": "/media/tv/The Last of Us (2023) [imdb-tt3581920] [tvdbid-392256]/Season 01/The Last of Us (2023) - S01E01 - When You're Lost in the Darkness [AMZN WEBDL-1080p Proper][EAC3 Atmos 5.1][h264]-FLUX.mkv",
 			"size": 6002269811,
 			"dateAdded": "2023-03-14T03:34:28Z",
-			"sceneName": "The.Last.Of.Us.S01E01.When.Youre.Lost.in.the.Darkness.REPACK.1080p.AMZN.WEB-DL.DDP5.1.Atmos.H.264-FLUX",
+			"sceneName": "The.Last.Of.Us.S01E01.When.Your.Lost.in.the.Darkness.REPACK.1080p.AMZN.WEB-DL.DDP5.1.Atmos.H.264-FLUX",
 			"releaseGroup": "FLUX",
 			"languages": [
 				{


### PR DESCRIPTION
The TLS Config passed into the http client gets overwritten; this fixes it.