### PR TITLE
Add Radarr - movie excludeLocalCovers

### DIFF
--- a/http.go
+++ b/http.go
@@ -189,6 +189,6 @@ func (r *ReqError) Error() string {
 
 // Is provides a custom error match facility.
 func (r *ReqError) Is(tgt error) bool {
-	target, ok := tgt.(*ReqError) //nolint:errorlint
+	target, ok := tgt.(*ReqError)
 	return ok && (r.Code == target.Code || target.Code == -1)
 }

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -101,7 +101,7 @@ type AlternativeTitle struct {
 }
 
 // GetMovie grabs a movie from the queue, or all movies if tmdbId is 0.
-func (r *Radarr) GetMovie(tmdbID int64) ([]*Movie, error) {
+func (r *Radarr) GetMovie(tmdbID int64, excludeLocalCovers bool) ([]*Movie, error) {
 	return r.GetMovieContext(context.Background(), tmdbID, excludeLocalCovers)
 }
 

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -106,7 +106,7 @@ func (r *Radarr) GetMovie(tmdbID int64, excludeLocalCovers bool) ([]*Movie, erro
 }
 
 // GetMovieContext grabs a movie from the queue, or all movies if tmdbId is 0.
-// excludeLocalCovers is only applicable to all movies endpoint and prevents radarr from spending IO mapping the local mediaCovers which speeds up /movie queries.
+// excludeLocalCovers is only applicable to all movies endpoint.
 func (r *Radarr) GetMovieContext(ctx context.Context, tmdbID int64, excludeLocalCovers bool) ([]*Movie, error) {
 	params := make(url.Values)
 	if tmdbID != 0 {

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -106,12 +106,13 @@ func (r *Radarr) GetMovie(tmdbID int64) ([]*Movie, error) {
 }
 
 // GetMovieContext grabs a movie from the queue, or all movies if tmdbId is 0.
+// excludeLocalCovers is only applicable to all movies endpoint
 func (r *Radarr) GetMovieContext(ctx context.Context, tmdbID int64, excludeLocalCovers bool) ([]*Movie, error) {
 	params := make(url.Values)
 	if tmdbID != 0 {
 		params.Set("tmdbId", fmt.Sprint(tmdbID))
 	}
-	if tmdbID = 0 {
+	if tmdbID == 0 {
 		params.Set("excludeLocalCovers", excludeLocalCovers)
 	}
 

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -110,10 +110,9 @@ func (r *Radarr) GetMovie(tmdbID int64, excludeLocalCovers bool) ([]*Movie, erro
 func (r *Radarr) GetMovieContext(ctx context.Context, tmdbID int64, excludeLocalCovers bool) ([]*Movie, error) {
 	params := make(url.Values)
 	if tmdbID != 0 {
-		params.Set("tmdbId", fmt.Sprint(tmdbID))
-	}
-	if tmdbID == 0 {
-		params.Set("excludeLocalCovers", fmt.Sprint(excludeLocalCovers))
+        	params.Set("tmdbId", fmt.Sprint(tmdbID))
+	} else {
+        	params.Set("excludeLocalCovers", fmt.Sprint(excludeLocalCovers))
 	}
 
 	var output []*Movie

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -106,12 +106,13 @@ func (r *Radarr) GetMovie(tmdbID int64, excludeLocalCovers bool) ([]*Movie, erro
 }
 
 // GetMovieContext grabs a movie from the queue, or all movies if tmdbId is 0.
-// excludeLocalCovers is only applicable to all movies endpoint
+// excludeLocalCovers is only applicable to all movies endpoint and prevents radarr from spending IO mapping the local mediaCovers which speeds up /movie queries.
 func (r *Radarr) GetMovieContext(ctx context.Context, tmdbID int64, excludeLocalCovers bool) ([]*Movie, error) {
 	params := make(url.Values)
 	if tmdbID != 0 {
 		params.Set("tmdbId", fmt.Sprint(tmdbID))
 	} else {
+		// excludeLocalCovers can only be used without a tmdbid.
 		params.Set("excludeLocalCovers", fmt.Sprint(excludeLocalCovers))
 	}
 

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -102,7 +102,7 @@ type AlternativeTitle struct {
 
 // GetMovie grabs a movie from the queue, or all movies if tmdbId is 0.
 func (r *Radarr) GetMovie(tmdbID int64) ([]*Movie, error) {
-	return r.GetMovieContext(context.Background(), tmdbID)
+	return r.GetMovieContext(context.Background(), tmdbID, excludeLocalCovers)
 }
 
 // GetMovieContext grabs a movie from the queue, or all movies if tmdbId is 0.

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -106,10 +106,13 @@ func (r *Radarr) GetMovie(tmdbID int64) ([]*Movie, error) {
 }
 
 // GetMovieContext grabs a movie from the queue, or all movies if tmdbId is 0.
-func (r *Radarr) GetMovieContext(ctx context.Context, tmdbID int64) ([]*Movie, error) {
+func (r *Radarr) GetMovieContext(ctx context.Context, tmdbID int64, excludeLocalCovers bool) ([]*Movie, error) {
 	params := make(url.Values)
 	if tmdbID != 0 {
 		params.Set("tmdbId", fmt.Sprint(tmdbID))
+	}
+	if tmdbID = 0 {
+		params.Set("excludeLocalCovers", excludeLocalCovers)
 	}
 
 	var output []*Movie

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -113,7 +113,7 @@ func (r *Radarr) GetMovieContext(ctx context.Context, tmdbID int64, excludeLocal
 		params.Set("tmdbId", fmt.Sprint(tmdbID))
 	}
 	if tmdbID == 0 {
-		params.Set("excludeLocalCovers", excludeLocalCovers)
+		params.Set("excludeLocalCovers", fmt.Sprint(excludeLocalCovers))
 	}
 
 	var output []*Movie

--- a/radarr/movie.go
+++ b/radarr/movie.go
@@ -110,9 +110,9 @@ func (r *Radarr) GetMovie(tmdbID int64, excludeLocalCovers bool) ([]*Movie, erro
 func (r *Radarr) GetMovieContext(ctx context.Context, tmdbID int64, excludeLocalCovers bool) ([]*Movie, error) {
 	params := make(url.Values)
 	if tmdbID != 0 {
-        	params.Set("tmdbId", fmt.Sprint(tmdbID))
+		params.Set("tmdbId", fmt.Sprint(tmdbID))
 	} else {
-        	params.Set("excludeLocalCovers", fmt.Sprint(excludeLocalCovers))
+		params.Set("excludeLocalCovers", fmt.Sprint(excludeLocalCovers))
 	}
 
 	var output []*Movie


### PR DESCRIPTION
don't need the local media covers file paths.....let's be more efficient
prior to fixup; massive speed improvements for posterity

only supported on `/api/movie` not `/api/movie/{ID}`

https://github.com/Notifiarr/notifiarr/issues/553
https://github.com/Radarr/Radarr/pull/8832