### PR TITLE
Updates

### DIFF
--- a/.github/workflows/codetests.yml
+++ b/.github/workflows/codetests.yml
@@ -47,9 +47,9 @@ jobs:
           go-version: stable
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: 'v1.54'
+          version: 'v1.57'
   # Runs golangci-lint on linux against linux and windows.
   golangci-linux:
     strategy:
@@ -65,6 +65,6 @@ jobs:
           go-version: stable
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: 'v1.54'
+          version: 'v1.57'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
   exclude-rules:
     # Exclude funlen for testing files.
     - linters:
@@ -36,7 +38,11 @@ linters:
     - nlreturn
     - tagalign
     - depguard
+    - musttag
+    - perfsprint # need to fix these
+    - testifylint # fix these too
 
+# One day we'll fix all the field alignments. Anyone got a tool that just does it?
 #linters-settings:
 #  govet:
 #    enable:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golift.io/starr
 
-go 1.17
+go 1.20
 
 require golang.org/x/net v0.22.0 // publicsuffix, cookiejar.
 

--- a/http_test.go
+++ b/http_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/starr"
 )
 
@@ -39,7 +40,7 @@ func TestReqError(t *testing.T) {
 	t.Parallel()
 
 	err := &starr.ReqError{Code: http.StatusForbidden}
-	assert.ErrorIs(t, err, starr.ErrInvalidStatusCode)
+	require.ErrorIs(t, err, starr.ErrInvalidStatusCode)
 	assert.Equal(t, "invalid status code, 403 >= 300", err.Error())
 
 	err.Body = []byte("Some Body")

--- a/lidarr/downloadclient.go
+++ b/lidarr/downloadclient.go
@@ -89,9 +89,12 @@ func (l *Lidarr) AddDownloadClient(downloadclient *DownloadClientInput) (*Downlo
 func (l *Lidarr) AddDownloadClientContext(ctx context.Context,
 	client *DownloadClientInput,
 ) (*DownloadClientOutput, error) {
-	var output DownloadClientOutput
+	var (
+		output DownloadClientOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	client.ID = 0
 	if err := json.NewEncoder(&body).Encode(client); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
 	}

--- a/lidarr/downloadclient.go
+++ b/lidarr/downloadclient.go
@@ -80,12 +80,12 @@ func (l *Lidarr) GetDownloadClientContext(ctx context.Context, downloadclientID 
 	return &output, nil
 }
 
-// AddDownloadClient creates a download client.
+// AddDownloadClient creates a download client without testing it.
 func (l *Lidarr) AddDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
 	return l.AddDownloadClientContext(context.Background(), downloadclient)
 }
 
-// AddDownloadClientContext creates a download client.
+// AddDownloadClientContext creates a download client without testing it.
 func (l *Lidarr) AddDownloadClientContext(ctx context.Context,
 	client *DownloadClientInput,
 ) (*DownloadClientOutput, error) {
@@ -96,7 +96,7 @@ func (l *Lidarr) AddDownloadClientContext(ctx context.Context,
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
 	}
 
-	req := starr.Request{URI: bpDownloadClient, Body: &body}
+	req := starr.Request{URI: bpDownloadClient, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := l.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/lidarr/downloadclient_test.go
+++ b/lidarr/downloadclient_test.go
@@ -225,7 +225,7 @@ func TestAddDownloadClient(t *testing.T) {
 	tests := []*starrtest.MockData{
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient"),
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 200,
 			WithRequest: &lidarr.DownloadClientInput{
@@ -297,7 +297,7 @@ func TestAddDownloadClient(t *testing.T) {
 		},
 		{
 			Name:           "404",
-			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient"),
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "downloadClient?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
 			WithRequest: &lidarr.DownloadClientInput{

--- a/lidarr/exclusions.go
+++ b/lidarr/exclusions.go
@@ -80,3 +80,27 @@ func (l *Lidarr) DeleteExclusionsContext(ctx context.Context, ids []int64) error
 
 	return nil
 }
+
+// AddExclusion adds one exclusion to Lidarr.
+func (l *Lidarr) AddExclusion(exclusion *Exclusion) (*Exclusion, error) {
+	return l.AddExclusionContext(context.Background(), exclusion)
+}
+
+// AddExclusionContext adds one exclusion to Lidarr.
+func (l *Lidarr) AddExclusionContext(ctx context.Context, exclusion *Exclusion) (*Exclusion, error) {
+	exclusion.ID = 0 // if this panics, fix your code
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(exclusion); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpExclusions, err)
+	}
+
+	var output Exclusion
+
+	req := starr.Request{URI: path.Join(bpExclusions), Body: &body}
+	if err := l.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}

--- a/lidarr/importlist.go
+++ b/lidarr/importlist.go
@@ -100,9 +100,12 @@ func (l *Lidarr) AddImportList(importList *ImportListInput) (*ImportListOutput, 
 
 // AddImportListContext creates an import list without testing it.
 func (l *Lidarr) AddImportListContext(ctx context.Context, importList *ImportListInput) (*ImportListOutput, error) {
-	var output ImportListOutput
+	var (
+		output ImportListOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	importList.ID = 0
 	if err := json.NewEncoder(&body).Encode(importList); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpImportList, err)
 	}

--- a/lidarr/importlist.go
+++ b/lidarr/importlist.go
@@ -93,12 +93,12 @@ func (l *Lidarr) GetImportListContext(ctx context.Context, importListID int64) (
 	return &output, nil
 }
 
-// AddImportList creates a import list.
+// AddImportList creates an import list without testing it.
 func (l *Lidarr) AddImportList(importList *ImportListInput) (*ImportListOutput, error) {
 	return l.AddImportListContext(context.Background(), importList)
 }
 
-// AddImportListContext creates a import list.
+// AddImportListContext creates an import list without testing it.
 func (l *Lidarr) AddImportListContext(ctx context.Context, importList *ImportListInput) (*ImportListOutput, error) {
 	var output ImportListOutput
 
@@ -107,7 +107,7 @@ func (l *Lidarr) AddImportListContext(ctx context.Context, importList *ImportLis
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpImportList, err)
 	}
 
-	req := starr.Request{URI: bpImportList, Body: &body}
+	req := starr.Request{URI: bpImportList, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := l.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/lidarr/indexer.go
+++ b/lidarr/indexer.go
@@ -110,9 +110,12 @@ func (l *Lidarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
 
 // AddIndexerContext creates an indexer without testing it.
 func (l *Lidarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
-	var output IndexerOutput
+	var (
+		output IndexerOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	indexer.ID = 0
 	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
 	}

--- a/lidarr/indexer.go
+++ b/lidarr/indexer.go
@@ -103,12 +103,12 @@ func (l *Lidarr) GetIndexerContext(ctx context.Context, indexerID int64) (*Index
 	return &output, nil
 }
 
-// AddIndexer creates a indexer.
+// AddIndexer creates an indexer without testing it.
 func (l *Lidarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
 	return l.AddIndexerContext(context.Background(), indexer)
 }
 
-// AddIndexerContext creates a indexer.
+// AddIndexerContext creates an indexer without testing it.
 func (l *Lidarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
 	var output IndexerOutput
 
@@ -117,7 +117,7 @@ func (l *Lidarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
 	}
 
-	req := starr.Request{URI: bpIndexer, Body: &body}
+	req := starr.Request{URI: bpIndexer, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := l.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/lidarr/indexer.go
+++ b/lidarr/indexer.go
@@ -91,7 +91,7 @@ func (l *Lidarr) TestIndexerContext(ctx context.Context, indexer *IndexerInput) 
 	return nil
 }
 
-// GetIndGetIndexerContextexer returns a single indexer.
+// GetIndexerContext returns a single indexer.
 func (l *Lidarr) GetIndexerContext(ctx context.Context, indexerID int64) (*IndexerOutput, error) {
 	var output IndexerOutput
 

--- a/lidarr/indexer_test.go
+++ b/lidarr/indexer_test.go
@@ -211,7 +211,7 @@ func TestAddIndexer(t *testing.T) {
 	tests := []*starrtest.MockData{
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "indexer"),
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "indexer?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 200,
 			WithRequest: &lidarr.IndexerInput{
@@ -276,7 +276,7 @@ func TestAddIndexer(t *testing.T) {
 		},
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "indexer"),
+			ExpectedPath:   path.Join("/", starr.API, lidarr.APIver, "indexer?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
 			WithRequest: &lidarr.IndexerInput{

--- a/lidarr/indexerconfig_test.go
+++ b/lidarr/indexerconfig_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/starr"
 	"golift.io/starr/lidarr"
 	"golift.io/starr/starrtest"
@@ -115,7 +116,7 @@ func TestUpdateIndexerConfig(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.UpdateIndexerConfig(test.WithRequest.(*lidarr.IndexerConfig))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
 		})
 	}

--- a/lidarr/notification_test.go
+++ b/lidarr/notification_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/starr"
 	"golift.io/starr/lidarr"
 	"golift.io/starr/starrtest"
@@ -141,7 +142,7 @@ func TestGetNotifications(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.GetNotifications()
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
 	}
@@ -217,7 +218,7 @@ func TestGetNotification(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.GetNotification(1)
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
 	}
@@ -317,7 +318,7 @@ func TestAddNotification(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.AddNotification(test.WithRequest.(*lidarr.NotificationInput))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
 	}
@@ -419,7 +420,7 @@ func TestUpdateNotification(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.UpdateNotification(test.WithRequest.(*lidarr.NotificationInput))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
 	}
@@ -456,7 +457,7 @@ func TestDeleteNotification(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := lidarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			err := client.DeleteNotification(test.WithRequest.(int64))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 		})
 	}
 }

--- a/lidarr/qualityprofile.go
+++ b/lidarr/qualityprofile.go
@@ -48,12 +48,15 @@ func (l *Lidarr) AddQualityProfile(profile *QualityProfile) (int64, error) {
 
 // AddQualityProfileContext updates a quality profile in place.
 func (l *Lidarr) AddQualityProfileContext(ctx context.Context, profile *QualityProfile) (int64, error) {
-	var body bytes.Buffer
+	var (
+		output QualityProfile
+		body   bytes.Buffer
+	)
+
+	profile.ID = 0
 	if err := json.NewEncoder(&body).Encode(profile); err != nil {
 		return 0, fmt.Errorf("json.Marshal(%s): %w", bpQualityProfile, err)
 	}
-
-	var output QualityProfile
 
 	req := starr.Request{URI: bpQualityProfile, Body: &body}
 	if err := l.PostInto(ctx, req, &output); err != nil {

--- a/prowlarr/downloadclient.go
+++ b/prowlarr/downloadclient.go
@@ -85,9 +85,12 @@ func (p *Prowlarr) AddDownloadClient(downloadclient *DownloadClientInput) (*Down
 func (p *Prowlarr) AddDownloadClientContext(ctx context.Context,
 	client *DownloadClientInput,
 ) (*DownloadClientOutput, error) {
-	var output DownloadClientOutput
+	var (
+		output DownloadClientOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	client.ID = 0
 	if err := json.NewEncoder(&body).Encode(client); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
 	}

--- a/prowlarr/downloadclient.go
+++ b/prowlarr/downloadclient.go
@@ -76,12 +76,12 @@ func (p *Prowlarr) GetDownloadClientContext(ctx context.Context, clientID int64)
 	return &output, nil
 }
 
-// AddDownloadClient creates a download client.
+// AddDownloadClient creates a download client without testing it.
 func (p *Prowlarr) AddDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
 	return p.AddDownloadClientContext(context.Background(), downloadclient)
 }
 
-// AddDownloadClientContext creates a download client.
+// AddDownloadClientContext creates a download client without testing it.
 func (p *Prowlarr) AddDownloadClientContext(ctx context.Context,
 	client *DownloadClientInput,
 ) (*DownloadClientOutput, error) {
@@ -92,7 +92,7 @@ func (p *Prowlarr) AddDownloadClientContext(ctx context.Context,
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
 	}
 
-	req := starr.Request{URI: bpDownloadClient, Body: &body}
+	req := starr.Request{URI: bpDownloadClient, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := p.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/prowlarr/downloadclient_test.go
+++ b/prowlarr/downloadclient_test.go
@@ -221,7 +221,7 @@ func TestAddDownloadClient(t *testing.T) {
 	tests := []*starrtest.MockData{
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient"),
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 200,
 			WithRequest: &prowlarr.DownloadClientInput{
@@ -291,7 +291,7 @@ func TestAddDownloadClient(t *testing.T) {
 		},
 		{
 			Name:           "404",
-			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient"),
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "downloadClient?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
 			WithRequest: &prowlarr.DownloadClientInput{

--- a/prowlarr/indexer.go
+++ b/prowlarr/indexer.go
@@ -123,7 +123,7 @@ func (p *Prowlarr) GetIndexer(indexerID int64) (*IndexerOutput, error) {
 	return p.GetIndexerContext(context.Background(), indexerID)
 }
 
-// GetIndGetIndexerContextexer returns a single indexer.
+// GetIndexerContext returns a single indexer.
 func (p *Prowlarr) GetIndexerContext(ctx context.Context, indexerID int64) (*IndexerOutput, error) {
 	var output IndexerOutput
 
@@ -135,12 +135,12 @@ func (p *Prowlarr) GetIndexerContext(ctx context.Context, indexerID int64) (*Ind
 	return &output, nil
 }
 
-// AddIndexer creates a indexer.
+// AddIndexer creates an indexer without testing it.
 func (p *Prowlarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
 	return p.AddIndexerContext(context.Background(), indexer)
 }
 
-// AddIndexerContext creates a indexer.
+// AddIndexerContext creates an indexer without testing it.
 func (p *Prowlarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
 	var output IndexerOutput
 
@@ -149,7 +149,7 @@ func (p *Prowlarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput)
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
 	}
 
-	req := starr.Request{URI: bpIndexer, Body: &body}
+	req := starr.Request{URI: bpIndexer, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := p.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/prowlarr/indexer.go
+++ b/prowlarr/indexer.go
@@ -142,9 +142,12 @@ func (p *Prowlarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
 
 // AddIndexerContext creates an indexer without testing it.
 func (p *Prowlarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
-	var output IndexerOutput
+	var (
+		output IndexerOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	indexer.ID = 0
 	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
 	}

--- a/prowlarr/indexer_test.go
+++ b/prowlarr/indexer_test.go
@@ -279,7 +279,7 @@ func TestAddIndexer(t *testing.T) {
 	tests := []*starrtest.MockData{
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "indexer"),
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "indexer?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 200,
 			WithRequest: &prowlarr.IndexerInput{
@@ -308,7 +308,7 @@ func TestAddIndexer(t *testing.T) {
 		},
 		{
 			Name:           "404",
-			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "indexer"),
+			ExpectedPath:   path.Join("/", starr.API, prowlarr.APIver, "indexer?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
 			WithRequest: &prowlarr.IndexerInput{

--- a/prowlarr/notification_test.go
+++ b/prowlarr/notification_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/starr"
 	"golift.io/starr/prowlarr"
 	"golift.io/starr/starrtest"
@@ -302,7 +303,7 @@ func TestAddNotification(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.AddNotification(test.WithRequest.(*prowlarr.NotificationInput))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
 	}
@@ -404,7 +405,7 @@ func TestUpdateNotification(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.UpdateNotification(test.WithRequest.(*prowlarr.NotificationInput))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
 	}

--- a/prowlarr/tag_test.go
+++ b/prowlarr/tag_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/starr"
 	"golift.io/starr/prowlarr"
 	"golift.io/starr/starrtest"
@@ -93,7 +94,7 @@ func TestGetTag(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := prowlarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.GetTag(test.WithRequest.(int))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
 	}

--- a/radarr/downloadclient.go
+++ b/radarr/downloadclient.go
@@ -89,9 +89,12 @@ func (r *Radarr) AddDownloadClient(downloadclient *DownloadClientInput) (*Downlo
 func (r *Radarr) AddDownloadClientContext(ctx context.Context,
 	client *DownloadClientInput,
 ) (*DownloadClientOutput, error) {
-	var output DownloadClientOutput
+	var (
+		output DownloadClientOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	client.ID = 0
 	if err := json.NewEncoder(&body).Encode(client); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
 	}

--- a/radarr/downloadclient.go
+++ b/radarr/downloadclient.go
@@ -80,12 +80,12 @@ func (r *Radarr) GetDownloadClientContext(ctx context.Context, downloadclientID 
 	return &output, nil
 }
 
-// AddDownloadClient creates a download client.
+// AddDownloadClient creates a download client without testing it.
 func (r *Radarr) AddDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
 	return r.AddDownloadClientContext(context.Background(), downloadclient)
 }
 
-// AddDownloadClientContext creates a download client.
+// AddDownloadClientContext creates a download client without testing it.
 func (r *Radarr) AddDownloadClientContext(ctx context.Context,
 	client *DownloadClientInput,
 ) (*DownloadClientOutput, error) {
@@ -96,7 +96,7 @@ func (r *Radarr) AddDownloadClientContext(ctx context.Context,
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
 	}
 
-	req := starr.Request{URI: bpDownloadClient, Body: &body}
+	req := starr.Request{URI: bpDownloadClient, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := r.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/radarr/downloadclient_test.go
+++ b/radarr/downloadclient_test.go
@@ -225,7 +225,7 @@ func TestAddDownloadClient(t *testing.T) {
 	tests := []*starrtest.MockData{
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient"),
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 200,
 			WithRequest: &radarr.DownloadClientInput{
@@ -297,7 +297,7 @@ func TestAddDownloadClient(t *testing.T) {
 		},
 		{
 			Name:           "404",
-			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient"),
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "downloadClient?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
 			WithRequest: &radarr.DownloadClientInput{

--- a/radarr/exclusions.go
+++ b/radarr/exclusions.go
@@ -107,3 +107,27 @@ func (r *Radarr) AddExclusionsContext(ctx context.Context, exclusions []*Exclusi
 
 	return nil
 }
+
+// AddExclusion adds one exclusion to Radarr.
+func (r *Radarr) AddExclusion(exclusion *Exclusion) (*Exclusion, error) {
+	return r.AddExclusionContext(context.Background(), exclusion)
+}
+
+// AddExclusionContext adds one exclusion to Radarr.
+func (r *Radarr) AddExclusionContext(ctx context.Context, exclusion *Exclusion) (*Exclusion, error) {
+	exclusion.ID = 0 // if this panics, fix your code
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(exclusion); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpExclusions, err)
+	}
+
+	var output Exclusion
+
+	req := starr.Request{URI: path.Join(bpExclusions), Body: &body}
+	if err := r.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}

--- a/radarr/importlist.go
+++ b/radarr/importlist.go
@@ -79,14 +79,15 @@ func (r *Radarr) AddImportList(list *ImportListInput) (*ImportListOutput, error)
 
 // AddImportListContext creates an import list in Radarr without testing it.
 func (r *Radarr) AddImportListContext(ctx context.Context, list *ImportListInput) (*ImportListOutput, error) {
-	list.ID = 0
+	var (
+		output ImportListOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	list.ID = 0
 	if err := json.NewEncoder(&body).Encode(list); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpImportList, err)
 	}
-
-	var output ImportListOutput
 
 	req := starr.Request{URI: bpImportList, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := r.PostInto(ctx, req, &output); err != nil {

--- a/radarr/importlist.go
+++ b/radarr/importlist.go
@@ -72,13 +72,13 @@ func (r *Radarr) GetImportListsContext(ctx context.Context) ([]*ImportListOutput
 	return output, nil
 }
 
-// CreateImportList creates an import list in Radarr.
+// AddImportList creates an import list in Radarr without testing it.
 func (r *Radarr) CreateImportList(list *ImportListInput) (*ImportListOutput, error) {
-	return r.CreateImportListContext(context.Background(), list)
+	return r.AddImportListContext(context.Background(), list)
 }
 
-// CreateImportListContext creates an import list in Radarr.
-func (r *Radarr) CreateImportListContext(ctx context.Context, list *ImportListInput) (*ImportListOutput, error) {
+// AddImportListContext creates an import list in Radarr without testing it.
+func (r *Radarr) AddImportListContext(ctx context.Context, list *ImportListInput) (*ImportListOutput, error) {
 	list.ID = 0
 
 	var body bytes.Buffer
@@ -88,7 +88,7 @@ func (r *Radarr) CreateImportListContext(ctx context.Context, list *ImportListIn
 
 	var output ImportListOutput
 
-	req := starr.Request{URI: bpImportList, Body: &body}
+	req := starr.Request{URI: bpImportList, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := r.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/radarr/importlist.go
+++ b/radarr/importlist.go
@@ -73,7 +73,7 @@ func (r *Radarr) GetImportListsContext(ctx context.Context) ([]*ImportListOutput
 }
 
 // AddImportList creates an import list in Radarr without testing it.
-func (r *Radarr) CreateImportList(list *ImportListInput) (*ImportListOutput, error) {
+func (r *Radarr) AddImportList(list *ImportListInput) (*ImportListOutput, error) {
 	return r.AddImportListContext(context.Background(), list)
 }
 

--- a/radarr/indexer.go
+++ b/radarr/indexer.go
@@ -112,9 +112,12 @@ func (r *Radarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
 
 // AddIndexerContext creates an indexer without testing it.
 func (r *Radarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
-	var output IndexerOutput
+	var (
+		output IndexerOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	indexer.ID = 0
 	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
 	}

--- a/radarr/indexer.go
+++ b/radarr/indexer.go
@@ -71,7 +71,7 @@ func (r *Radarr) GetIndexer(indexerID int64) (*IndexerOutput, error) {
 	return r.GetIndexerContext(context.Background(), indexerID)
 }
 
-// GetIndGetIndexerContextexer returns a single indexer.
+// GetIndexerContext returns a single indexer.
 func (r *Radarr) GetIndexerContext(ctx context.Context, indexerID int64) (*IndexerOutput, error) {
 	var output IndexerOutput
 
@@ -105,12 +105,12 @@ func (r *Radarr) TestIndexerContext(ctx context.Context, indexer *IndexerInput) 
 	return nil
 }
 
-// AddIndexer creates a indexer.
+// AddIndexer creates an indexer without testing it.
 func (r *Radarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
 	return r.AddIndexerContext(context.Background(), indexer)
 }
 
-// AddIndexerContext creates a indexer.
+// AddIndexerContext creates an indexer without testing it.
 func (r *Radarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
 	var output IndexerOutput
 
@@ -119,7 +119,7 @@ func (r *Radarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
 	}
 
-	req := starr.Request{URI: bpIndexer, Body: &body}
+	req := starr.Request{URI: bpIndexer, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := r.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/radarr/indexer_test.go
+++ b/radarr/indexer_test.go
@@ -212,7 +212,7 @@ func TestAddIndexer(t *testing.T) {
 	tests := []*starrtest.MockData{
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer"),
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 200,
 			WithRequest: &radarr.IndexerInput{
@@ -278,7 +278,7 @@ func TestAddIndexer(t *testing.T) {
 		},
 		{
 			Name:           "404",
-			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer"),
+			ExpectedPath:   path.Join("/", starr.API, radarr.APIver, "indexer?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
 			WithRequest: &radarr.IndexerInput{

--- a/radarr/mediamanagement.go
+++ b/radarr/mediamanagement.go
@@ -14,6 +14,7 @@ const bpMediaManagement = APIver + "/config/mediaManagement"
 
 // MediaManagement represents the /config/mediaManagement endpoint.
 type MediaManagement struct {
+	UseScriptImport                         bool   `json:"useScriptImport,omitempty"`
 	AutoRenameFolders                       bool   `json:"autoRenameFolders,omitempty"`
 	AutoUnmonitorPreviouslyDownloadedMovies bool   `json:"autoUnmonitorPreviouslyDownloadedMovies,omitempty"`
 	CopyUsingHardlinks                      bool   `json:"copyUsingHardlinks,omitempty"`
@@ -27,6 +28,7 @@ type MediaManagement struct {
 	ID                                      int64  `json:"id"`
 	MinimumFreeSpaceWhenImporting           int64  `json:"minimumFreeSpaceWhenImporting"` // 0 or empty not allowed
 	RecycleBinCleanupDays                   int64  `json:"recycleBinCleanupDays,omitempty"`
+	ScriptImportPath                        string `json:"scriptImportPath,omitempty"`
 	ChmodFolder                             string `json:"chmodFolder,omitempty"`
 	ChownGroup                              string `json:"chownGroup"` // empty string is valid
 	DownloadPropersAndRepacks               string `json:"downloadPropersAndRepacks,omitempty"`

--- a/radarr/naming.go
+++ b/radarr/naming.go
@@ -16,15 +16,22 @@ const bpNaming = APIver + "/config/naming"
 type Naming struct {
 	RenameMovies             bool   `json:"renameMovies,omitempty"`
 	ReplaceIllegalCharacters bool   `json:"replaceIllegalCharacters,omitempty"`
-	IncludeQuality           bool   `json:"includeQuality,omitempty"`
-	ReplaceSpaces            bool   `json:"replaceSpaces,omitempty"`
 	ID                       int64  `json:"id"` // ID must always be 1 (Oct 10, 2022)
-	ColonReplacementFormat   string `json:"colonReplacementFormat,omitempty"`
+	ColonReplacementFormat   CRF    `json:"colonReplacementFormat,omitempty"`
 	StandardMovieFormat      string `json:"standardMovieFormat"` // required
 	MovieFolderFormat        string `json:"movieFolderFormat"`   // required
-	Separator                string `json:"separatort,omitempty"`
-	NumberStyle              string `json:"numberStylet,omitempty"`
 }
+
+// CRF is ColonReplacementFormat, for naming config.
+type CRF string
+
+// These are all of the possible Colon Replacement Formats (for naming config) in Radarr.
+const (
+	ColonDelete                    CRF = "delete"
+	ColonReplaceWithDash           CRF = "dash"
+	ColonReplaceWithSpaceDash      CRF = "spaceDash"
+	ColonReplaceWithSpaceDashSpace CRF = "spaceDashSpace"
+)
 
 // GetNaming returns the file naming rules.
 func (r *Radarr) GetNaming() (*Naming, error) {
@@ -50,9 +57,12 @@ func (r *Radarr) UpdateNaming(naming *Naming) (*Naming, error) {
 
 // UpdateNamingContext updates the file naming rules.
 func (r *Radarr) UpdateNamingContext(ctx context.Context, naming *Naming) (*Naming, error) {
-	var output Naming
+	var (
+		output Naming
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	naming.ID = 1
 	if err := json.NewEncoder(&body).Encode(naming); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpNaming, err)
 	}

--- a/radarr/naming_test.go
+++ b/radarr/naming_test.go
@@ -17,8 +17,6 @@ const namingBody = `{
 	"colonReplacementFormat": "delete",
 	"standardMovieFormat": "{Movie.Title}.{Release.Year}.{Quality.Title}",
 	"movieFolderFormat": "{Movie Title} ({Release Year})",
-	"includeQuality": true,
-	"replaceSpaces": true,
 	"id": 1
   }`
 
@@ -35,10 +33,8 @@ func TestGetNaming(t *testing.T) {
 			WithResponse: &radarr.Naming{
 				ID:                       1,
 				ReplaceIllegalCharacters: true,
-				IncludeQuality:           true,
-				ReplaceSpaces:            true,
 				RenameMovies:             true,
-				ColonReplacementFormat:   "delete",
+				ColonReplacementFormat:   radarr.ColonDelete,
 				StandardMovieFormat:      "{Movie.Title}.{Release.Year}.{Quality.Title}",
 				MovieFolderFormat:        "{Movie Title} ({Release Year})",
 			},
@@ -87,8 +83,6 @@ func TestUpdateNaming(t *testing.T) {
 			WithResponse: &radarr.Naming{
 				ID:                       1,
 				ReplaceIllegalCharacters: true,
-				IncludeQuality:           true,
-				ReplaceSpaces:            true,
 				RenameMovies:             true,
 				ColonReplacementFormat:   "delete",
 				StandardMovieFormat:      "{Movie.Title}.{Release.Year}.{Quality.Title}",

--- a/radarr/qualityprofile.go
+++ b/radarr/qualityprofile.go
@@ -66,9 +66,12 @@ func (r *Radarr) AddQualityProfile(profile *QualityProfile) (*QualityProfile, er
 
 // AddQualityProfileContext updates a quality profile in place.
 func (r *Radarr) AddQualityProfileContext(ctx context.Context, profile *QualityProfile) (*QualityProfile, error) {
-	var output QualityProfile
+	var (
+		output QualityProfile
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	profile.ID = 0
 	if err := json.NewEncoder(&body).Encode(profile); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpQualityProfile, err)
 	}

--- a/readarr/downloadclient.go
+++ b/readarr/downloadclient.go
@@ -77,12 +77,12 @@ func (r *Readarr) GetDownloadClientContext(ctx context.Context, downloadclientID
 	return &output, nil
 }
 
-// AddDownloadClient creates a download client.
+// AddDownloadClient creates a download client without testing it.
 func (r *Readarr) AddDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
 	return r.AddDownloadClientContext(context.Background(), downloadclient)
 }
 
-// AddDownloadClientContext creates a download client.
+// AddDownloadClientContext creates a download client without testing it.
 func (r *Readarr) AddDownloadClientContext(ctx context.Context,
 	client *DownloadClientInput,
 ) (*DownloadClientOutput, error) {
@@ -93,7 +93,7 @@ func (r *Readarr) AddDownloadClientContext(ctx context.Context,
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
 	}
 
-	req := starr.Request{URI: bpDownloadClient, Body: &body}
+	req := starr.Request{URI: bpDownloadClient, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := r.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/readarr/downloadclient.go
+++ b/readarr/downloadclient.go
@@ -86,9 +86,12 @@ func (r *Readarr) AddDownloadClient(downloadclient *DownloadClientInput) (*Downl
 func (r *Readarr) AddDownloadClientContext(ctx context.Context,
 	client *DownloadClientInput,
 ) (*DownloadClientOutput, error) {
-	var output DownloadClientOutput
+	var (
+		output DownloadClientOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	client.ID = 0
 	if err := json.NewEncoder(&body).Encode(client); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
 	}

--- a/readarr/downloadclient_test.go
+++ b/readarr/downloadclient_test.go
@@ -217,7 +217,7 @@ func TestAddDownloadClient(t *testing.T) {
 	tests := []*starrtest.MockData{
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient"),
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 200,
 			WithRequest: &readarr.DownloadClientInput{
@@ -287,7 +287,7 @@ func TestAddDownloadClient(t *testing.T) {
 		},
 		{
 			Name:           "404",
-			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient"),
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "downloadClient?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
 			WithRequest: &readarr.DownloadClientInput{

--- a/readarr/exclusions.go
+++ b/readarr/exclusions.go
@@ -80,3 +80,27 @@ func (r *Readarr) DeleteExclusionsContext(ctx context.Context, ids []int64) erro
 
 	return nil
 }
+
+// AddExclusion adds one exclusion to Readarr.
+func (r *Readarr) AddExclusion(exclusion *Exclusion) (*Exclusion, error) {
+	return r.AddExclusionContext(context.Background(), exclusion)
+}
+
+// AddExclusionContext adds one exclusion to Readarr.
+func (r *Readarr) AddExclusionContext(ctx context.Context, exclusion *Exclusion) (*Exclusion, error) {
+	exclusion.ID = 0 // if this panics, fix your code
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(exclusion); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpExclusions, err)
+	}
+
+	var output Exclusion
+
+	req := starr.Request{URI: path.Join(bpExclusions), Body: &body}
+	if err := r.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}

--- a/readarr/importlist.go
+++ b/readarr/importlist.go
@@ -96,9 +96,12 @@ func (r *Readarr) AddImportList(importList *ImportListInput) (*ImportListOutput,
 
 // AddImportListContext creates an import list without testing it.
 func (r *Readarr) AddImportListContext(ctx context.Context, importList *ImportListInput) (*ImportListOutput, error) {
-	var output ImportListOutput
+	var (
+		output ImportListOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	importList.ID = 0
 	if err := json.NewEncoder(&body).Encode(importList); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpImportList, err)
 	}

--- a/readarr/importlist.go
+++ b/readarr/importlist.go
@@ -89,12 +89,12 @@ func (r *Readarr) GetImportListContext(ctx context.Context, importListID int64) 
 	return &output, nil
 }
 
-// AddImportList creates a import list.
+// AddImportList creates an import list without testing it.
 func (r *Readarr) AddImportList(importList *ImportListInput) (*ImportListOutput, error) {
 	return r.AddImportListContext(context.Background(), importList)
 }
 
-// AddImportListContext creates a import list.
+// AddImportListContext creates an import list without testing it.
 func (r *Readarr) AddImportListContext(ctx context.Context, importList *ImportListInput) (*ImportListOutput, error) {
 	var output ImportListOutput
 
@@ -103,7 +103,7 @@ func (r *Readarr) AddImportListContext(ctx context.Context, importList *ImportLi
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpImportList, err)
 	}
 
-	req := starr.Request{URI: bpImportList, Body: &body}
+	req := starr.Request{URI: bpImportList, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := r.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/readarr/indexer.go
+++ b/readarr/indexer.go
@@ -103,12 +103,12 @@ func (r *Readarr) TestIndexerContext(ctx context.Context, indexer *IndexerInput)
 	return nil
 }
 
-// AddIndexer creates a indexer.
+// AddIndexer creates an indexer without testing it.
 func (r *Readarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
 	return r.AddIndexerContext(context.Background(), indexer)
 }
 
-// AddIndexerContext creates a indexer.
+// AddIndexerContext creates an indexer without testing it.
 func (r *Readarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
 	var output IndexerOutput
 
@@ -117,7 +117,7 @@ func (r *Readarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) 
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
 	}
 
-	req := starr.Request{URI: bpIndexer, Body: &body}
+	req := starr.Request{URI: bpIndexer, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := r.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/readarr/indexer.go
+++ b/readarr/indexer.go
@@ -110,9 +110,12 @@ func (r *Readarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
 
 // AddIndexerContext creates an indexer without testing it.
 func (r *Readarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
-	var output IndexerOutput
+	var (
+		output IndexerOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	indexer.ID = 0
 	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
 	}

--- a/readarr/indexer_test.go
+++ b/readarr/indexer_test.go
@@ -211,7 +211,7 @@ func TestAddIndexer(t *testing.T) {
 	tests := []*starrtest.MockData{
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "indexer"),
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "indexer?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 200,
 			WithRequest: &readarr.IndexerInput{
@@ -276,7 +276,7 @@ func TestAddIndexer(t *testing.T) {
 		},
 		{
 			Name:           "404",
-			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "indexer"),
+			ExpectedPath:   path.Join("/", starr.API, readarr.APIver, "indexer?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
 			WithRequest: &readarr.IndexerInput{

--- a/readarr/qualityprofile.go
+++ b/readarr/qualityprofile.go
@@ -48,12 +48,15 @@ func (r *Readarr) AddQualityProfile(profile *QualityProfile) (int64, error) {
 
 // AddQualityProfileContext updates a quality profile in place.
 func (r *Readarr) AddQualityProfileContext(ctx context.Context, profile *QualityProfile) (int64, error) {
-	var body bytes.Buffer
+	var (
+		output QualityProfile
+		body   bytes.Buffer
+	)
+
+	profile.ID = 0
 	if err := json.NewEncoder(&body).Encode(profile); err != nil {
 		return 0, fmt.Errorf("json.Marshal(%s): %w", bpQualityProfile, err)
 	}
-
-	var output QualityProfile
 
 	req := starr.Request{URI: bpQualityProfile, Body: &body}
 	if err := r.PostInto(ctx, req, &output); err != nil {

--- a/shared.go
+++ b/shared.go
@@ -45,7 +45,7 @@ func (a App) Lower() string {
 func Client(timeout time.Duration, verifySSL bool) *http.Client {
 	return &http.Client{
 		Timeout: timeout,
-		CheckRedirect: func(r *http.Request, via []*http.Request) error {
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 		Transport: &http.Transport{
@@ -238,7 +238,7 @@ func (o *QueueDeleteOpts) Values() url.Values {
 
 // PlayTime is used in at least Sonarr, maybe other places.
 // Holds a string duration converted from hh:mm:ss.
-type PlayTime struct { //nolint:musttag
+type PlayTime struct {
 	Original string
 	time.Duration
 }

--- a/shared_test.go
+++ b/shared_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/starr"
 )
 
@@ -14,7 +15,7 @@ func TestQueueDeleteOpts_Values(t *testing.T) {
 	var opts *starr.QueueDeleteOpts
 
 	params := opts.Values() // it's nil.
-	assert.Equal(params.Encode(), "removeFromClient=true",
+	require.Equal(t, "removeFromClient=true", params.Encode(),
 		"default queue delete parameters encoded incorrectly")
 
 	opts = &starr.QueueDeleteOpts{

--- a/sonarr/downloadclient.go
+++ b/sonarr/downloadclient.go
@@ -80,12 +80,12 @@ func (s *Sonarr) GetDownloadClientContext(ctx context.Context, downloadclientID 
 	return &output, nil
 }
 
-// AddDownloadClient creates a download client.
+// AddDownloadClient creates a download client without testing it.
 func (s *Sonarr) AddDownloadClient(downloadclient *DownloadClientInput) (*DownloadClientOutput, error) {
 	return s.AddDownloadClientContext(context.Background(), downloadclient)
 }
 
-// AddDownloadClientContext creates a download client.
+// AddDownloadClientContext creates a download client without testing it.
 func (s *Sonarr) AddDownloadClientContext(ctx context.Context,
 	client *DownloadClientInput,
 ) (*DownloadClientOutput, error) {
@@ -96,7 +96,7 @@ func (s *Sonarr) AddDownloadClientContext(ctx context.Context,
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
 	}
 
-	req := starr.Request{URI: bpDownloadClient, Body: &body}
+	req := starr.Request{URI: bpDownloadClient, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := s.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/sonarr/downloadclient.go
+++ b/sonarr/downloadclient.go
@@ -89,9 +89,12 @@ func (s *Sonarr) AddDownloadClient(downloadclient *DownloadClientInput) (*Downlo
 func (s *Sonarr) AddDownloadClientContext(ctx context.Context,
 	client *DownloadClientInput,
 ) (*DownloadClientOutput, error) {
-	var output DownloadClientOutput
+	var (
+		output DownloadClientOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	client.ID = 0
 	if err := json.NewEncoder(&body).Encode(client); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpDownloadClient, err)
 	}

--- a/sonarr/downloadclient_test.go
+++ b/sonarr/downloadclient_test.go
@@ -225,7 +225,7 @@ func TestAddDownloadClient(t *testing.T) {
 	tests := []*starrtest.MockData{
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "downloadClient"),
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "downloadClient?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 200,
 			WithRequest: &sonarr.DownloadClientInput{
@@ -297,7 +297,7 @@ func TestAddDownloadClient(t *testing.T) {
 		},
 		{
 			Name:           "404",
-			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "downloadClient"),
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "downloadClient?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
 			WithRequest: &sonarr.DownloadClientInput{

--- a/sonarr/exclusions.go
+++ b/sonarr/exclusions.go
@@ -80,3 +80,27 @@ func (s *Sonarr) DeleteExclusionsContext(ctx context.Context, ids []int64) error
 
 	return nil
 }
+
+// AddExclusion adds one exclusion to Sonarr.
+func (s *Sonarr) AddExclusion(exclusion *Exclusion) (*Exclusion, error) {
+	return s.AddExclusionContext(context.Background(), exclusion)
+}
+
+// AddExclusionContext adds one exclusion to Sonarr.
+func (s *Sonarr) AddExclusionContext(ctx context.Context, exclusion *Exclusion) (*Exclusion, error) {
+	exclusion.ID = 0 // if this panics, fix your code
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(exclusion); err != nil {
+		return nil, fmt.Errorf("json.Marshal(%s): %w", bpExclusions, err)
+	}
+
+	var output Exclusion
+
+	req := starr.Request{URI: path.Join(bpExclusions), Body: &body}
+	if err := s.PostInto(ctx, req, &output); err != nil {
+		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
+	}
+
+	return &output, nil
+}

--- a/sonarr/importlist.go
+++ b/sonarr/importlist.go
@@ -89,12 +89,12 @@ func (s *Sonarr) GetImportListContext(ctx context.Context, importListID int64) (
 	return &output, nil
 }
 
-// AddImportList creates a import list.
+// AddImportList creates an import list without testing it.
 func (s *Sonarr) AddImportList(importList *ImportListInput) (*ImportListOutput, error) {
 	return s.AddImportListContext(context.Background(), importList)
 }
 
-// AddImportListContext creates a import list.
+// AddImportListContext creates an import list without testing it.
 func (s *Sonarr) AddImportListContext(ctx context.Context, importList *ImportListInput) (*ImportListOutput, error) {
 	var output ImportListOutput
 
@@ -103,7 +103,7 @@ func (s *Sonarr) AddImportListContext(ctx context.Context, importList *ImportLis
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpImportList, err)
 	}
 
-	req := starr.Request{URI: bpImportList, Body: &body}
+	req := starr.Request{URI: bpImportList, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := s.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/sonarr/importlist.go
+++ b/sonarr/importlist.go
@@ -96,9 +96,12 @@ func (s *Sonarr) AddImportList(importList *ImportListInput) (*ImportListOutput, 
 
 // AddImportListContext creates an import list without testing it.
 func (s *Sonarr) AddImportListContext(ctx context.Context, importList *ImportListInput) (*ImportListOutput, error) {
-	var output ImportListOutput
+	var (
+		output ImportListOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	importList.ID = 0
 	if err := json.NewEncoder(&body).Encode(importList); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpImportList, err)
 	}

--- a/sonarr/importlist_test.go
+++ b/sonarr/importlist_test.go
@@ -208,7 +208,7 @@ func TestAddImportList(t *testing.T) {
 	tests := []*starrtest.MockData{
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "importList"),
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "importList?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 200,
 			WithRequest: &sonarr.ImportListInput{
@@ -271,7 +271,7 @@ func TestAddImportList(t *testing.T) {
 		},
 		{
 			Name:           "404",
-			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "importList"),
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "importList?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
 			WithRequest: &sonarr.ImportListInput{

--- a/sonarr/indexer.go
+++ b/sonarr/indexer.go
@@ -112,9 +112,12 @@ func (s *Sonarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
 
 // AddIndexerContext creates an indexer without testing it.
 func (s *Sonarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
-	var output IndexerOutput
+	var (
+		output IndexerOutput
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	indexer.ID = 0
 	if err := json.NewEncoder(&body).Encode(indexer); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
 	}

--- a/sonarr/indexer.go
+++ b/sonarr/indexer.go
@@ -71,7 +71,7 @@ func (s *Sonarr) GetIndexer(indexerID int64) (*IndexerOutput, error) {
 	return s.GetIndexerContext(context.Background(), indexerID)
 }
 
-// GetIndGetIndexerContextexer returns a single indexer.
+// GetIndexerContext returns a single indexer.
 func (s *Sonarr) GetIndexerContext(ctx context.Context, indexerID int64) (*IndexerOutput, error) {
 	var output IndexerOutput
 
@@ -105,12 +105,12 @@ func (s *Sonarr) TestIndexerContext(ctx context.Context, indexer *IndexerInput) 
 	return nil
 }
 
-// AddIndexer creates a indexer.
+// AddIndexer creates an indexer without testing it.
 func (s *Sonarr) AddIndexer(indexer *IndexerInput) (*IndexerOutput, error) {
 	return s.AddIndexerContext(context.Background(), indexer)
 }
 
-// AddIndexerContext creates a indexer.
+// AddIndexerContext creates an indexer without testing it.
 func (s *Sonarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (*IndexerOutput, error) {
 	var output IndexerOutput
 
@@ -119,7 +119,7 @@ func (s *Sonarr) AddIndexerContext(ctx context.Context, indexer *IndexerInput) (
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpIndexer, err)
 	}
 
-	req := starr.Request{URI: bpIndexer, Body: &body}
+	req := starr.Request{URI: bpIndexer, Body: &body, Query: url.Values{"forceSave": []string{"true"}}}
 	if err := s.PostInto(ctx, req, &output); err != nil {
 		return nil, fmt.Errorf("api.Post(%s): %w", &req, err)
 	}

--- a/sonarr/indexer_test.go
+++ b/sonarr/indexer_test.go
@@ -212,7 +212,7 @@ func TestAddIndexer(t *testing.T) {
 	tests := []*starrtest.MockData{
 		{
 			Name:           "200",
-			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "indexer"),
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "indexer?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 200,
 			WithRequest: &sonarr.IndexerInput{
@@ -278,7 +278,7 @@ func TestAddIndexer(t *testing.T) {
 		},
 		{
 			Name:           "404",
-			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "indexer"),
+			ExpectedPath:   path.Join("/", starr.API, sonarr.APIver, "indexer?forceSave=true"),
 			ExpectedMethod: "POST",
 			ResponseStatus: 404,
 			WithRequest: &sonarr.IndexerInput{

--- a/sonarr/mediamanagement.go
+++ b/sonarr/mediamanagement.go
@@ -14,6 +14,7 @@ const bpMediaManagement = APIver + "/config/mediaManagement"
 
 // MediaManagement represents the /config/mediamanagement endpoint.
 type MediaManagement struct {
+	UseScriptImport                           bool   `json:"useScriptImport,omitempty"`
 	AutoUnmonitorPreviouslyDownloadedEpisodes bool   `json:"autoUnmonitorPreviouslyDownloadedEpisodes,omitempty"`
 	CopyUsingHardlinks                        bool   `json:"copyUsingHardlinks,omitempty"`
 	CreateEmptySeriesFolders                  bool   `json:"createEmptySeriesFolders,omitempty"`
@@ -25,6 +26,7 @@ type MediaManagement struct {
 	ID                                        int64  `json:"id"`
 	MinimumFreeSpaceWhenImporting             int64  `json:"minimumFreeSpaceWhenImporting"` // 0 or empty not allowed
 	RecycleBinCleanupDays                     int64  `json:"recycleBinCleanupDays,omitempty"`
+	ScriptImportPath                          string `json:"scriptImportPath,omitempty"`
 	ChmodFolder                               string `json:"chmodFolder,omitempty"`
 	ChownGroup                                string `json:"chownGroup"` // empty string is valid
 	DownloadPropersAndRepacks                 string `json:"downloadPropersAndRepacks,omitempty"`

--- a/sonarr/naming.go
+++ b/sonarr/naming.go
@@ -12,18 +12,25 @@ import (
 // Define Base Path for Naming calls.
 const bpNaming = APIver + "/config/naming"
 
+// CRF is ColonReplacementFormat, for naming config.
+type CRF int
+
+// These are all of the possible Colon Replacement Formats (for naming config) in Sonarr.
+const (
+	ColonDelete CRF = iota
+	ColonReplaceWithDash
+	ColonReplaceWithSpaceDash
+	ColonReplaceWithSpaceDashSpace
+	ColonSmartReplace
+)
+
 // Naming represents the config/naming endpoint in Sonarr.
 type Naming struct {
 	RenameEpisodes           bool   `json:"renameEpisodes,omitempty"`
 	ReplaceIllegalCharacters bool   `json:"replaceIllegalCharacters,omitempty"`
-	IncludeQuality           bool   `json:"includeQuality,omitempty"`
-	IncludeSeriesTitle       bool   `json:"includeSeriesTitle,omitempty"`
-	IncludeEpisodeTitle      bool   `json:"includeEpisodeTitle,omitempty"`
-	ReplaceSpaces            bool   `json:"replaceSpaces,omitempty"`
+	ColonReplacementFormat   CRF    `json:"colonReplacementFormat,omitempty"`
 	ID                       int64  `json:"id,omitempty"`
 	MultiEpisodeStyle        int64  `json:"multiEpisodeStyle,omitempty"`
-	Separator                string `json:"separator,omitempty"`
-	NumberStyle              string `json:"numberStyle,omitempty"`
 	DailyEpisodeFormat       string `json:"dailyEpisodeFormat,omitempty"`
 	AnimeEpisodeFormat       string `json:"animeEpisodeFormat,omitempty"`
 	SeriesFolderFormat       string `json:"seriesFolderFormat,omitempty"`
@@ -56,9 +63,12 @@ func (s *Sonarr) UpdateNaming(naming *Naming) (*Naming, error) {
 
 // UpdateNamingContext updates the naming.
 func (s *Sonarr) UpdateNamingContext(ctx context.Context, naming *Naming) (*Naming, error) {
-	var output Naming
+	var (
+		output Naming
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	naming.ID = 1
 	if err := json.NewEncoder(&body).Encode(naming); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpNaming, err)
 	}

--- a/sonarr/naming_test.go
+++ b/sonarr/naming_test.go
@@ -86,7 +86,7 @@ func TestUpdateNaming(t *testing.T) {
 			WithRequest: &sonarr.Naming{
 				ReplaceIllegalCharacters: true,
 			},
-			ExpectedRequest: `{"replaceIllegalCharacters":true}` + "\n",
+			ExpectedRequest: `{"replaceIllegalCharacters":true,"id":1}` + "\n",
 			ResponseBody:    namingBody,
 			WithResponse: &sonarr.Naming{
 				ID:                       1,
@@ -109,7 +109,7 @@ func TestUpdateNaming(t *testing.T) {
 			WithRequest: &sonarr.Naming{
 				ReplaceIllegalCharacters: true,
 			},
-			ExpectedRequest: `{"replaceIllegalCharacters":true}` + "\n",
+			ExpectedRequest: `{"replaceIllegalCharacters":true,"id":1}` + "\n",
 			ResponseStatus:  404,
 			ResponseBody:    `{"message": "NotFound"}`,
 			WithError:       &starr.ReqError{Code: http.StatusNotFound},

--- a/sonarr/naming_test.go
+++ b/sonarr/naming_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 const namingBody = `{
+	"colonReplacementFormat": 0,
 	"renameEpisodes": false,
 	"replaceIllegalCharacters": true,
 	"multiEpisodeStyle": 0,
@@ -21,12 +22,6 @@ const namingBody = `{
 	"seriesFolderFormat": "{Series Title}",
 	"seasonFolderFormat": "Season {season}",
 	"specialsFolderFormat": "Specials",
-	"includeSeriesTitle": true,
-	"includeEpisodeTitle": false,
-	"includeQuality": false,
-	"replaceSpaces": true,
-	"separator": " - ",
-	"numberStyle": "S{season:00}E{episode:00}",
 	"id": 1
 }`
 
@@ -51,12 +46,7 @@ func TestGetNaming(t *testing.T) {
 				SeriesFolderFormat:       "{Series Title}",
 				SeasonFolderFormat:       "Season {season}",
 				SpecialsFolderFormat:     "Specials",
-				IncludeSeriesTitle:       true,
-				IncludeEpisodeTitle:      false,
-				IncludeQuality:           false,
-				ReplaceSpaces:            true,
-				Separator:                " - ",
-				NumberStyle:              "S{season:00}E{episode:00}",
+				ColonReplacementFormat:   sonarr.ColonDelete,
 			},
 			WithError: nil,
 		},
@@ -109,12 +99,6 @@ func TestUpdateNaming(t *testing.T) {
 				SeriesFolderFormat:       "{Series Title}",
 				SeasonFolderFormat:       "Season {season}",
 				SpecialsFolderFormat:     "Specials",
-				IncludeSeriesTitle:       true,
-				IncludeEpisodeTitle:      false,
-				IncludeQuality:           false,
-				ReplaceSpaces:            true,
-				Separator:                " - ",
-				NumberStyle:              "S{season:00}E{episode:00}",
 			},
 			WithError: nil,
 		},

--- a/sonarr/qualityprofile.go
+++ b/sonarr/qualityprofile.go
@@ -67,9 +67,12 @@ func (s *Sonarr) AddQualityProfile(profile *QualityProfile) (*QualityProfile, er
 
 // AddQualityProfileContext creates a quality profile.
 func (s *Sonarr) AddQualityProfileContext(ctx context.Context, profile *QualityProfile) (*QualityProfile, error) {
-	var output QualityProfile
+	var (
+		output QualityProfile
+		body   bytes.Buffer
+	)
 
-	var body bytes.Buffer
+	profile.ID = 0
 	if err := json.NewEncoder(&body).Encode(profile); err != nil {
 		return nil, fmt.Errorf("json.Marshal(%s): %w", bpQualityProfile, err)
 	}

--- a/sonarr/rootfolder_test.go
+++ b/sonarr/rootfolder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/starr"
 	"golift.io/starr/sonarr"
 	"golift.io/starr/starrtest"
@@ -185,7 +186,7 @@ func TestAddRootFolder(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.AddRootFolder(test.WithRequest.(*sonarr.RootFolder))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
 	}

--- a/sonarr/series_test.go
+++ b/sonarr/series_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/starr"
 	"golift.io/starr/sonarr"
 	"golift.io/starr/starrtest"
@@ -1523,7 +1524,7 @@ func TestLookupName(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.Lookup(test.WithRequest.(string))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, output, test.WithResponse, "response is not the same as expected")
 		})
 	}

--- a/sonarr/tag_test.go
+++ b/sonarr/tag_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/starr"
 	"golift.io/starr/sonarr"
 	"golift.io/starr/starrtest"
@@ -141,7 +142,7 @@ func TestAddTag(t *testing.T) {
 			mockServer := test.GetMockServer(t)
 			client := sonarr.New(starr.New("mockAPIkey", mockServer.URL, 0))
 			output, err := client.AddTag(test.WithRequest.(*starr.Tag))
-			assert.ErrorIs(t, err, test.WithError, "error is not the same as expected")
+			require.ErrorIs(t, err, test.WithError, "error is not the same as expected")
 			assert.EqualValues(t, test.WithResponse, output, "response is not the same as expected")
 		})
 	}

--- a/starr.go
+++ b/starr.go
@@ -17,7 +17,7 @@
 package starr
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"time"
 )
@@ -34,13 +34,13 @@ var (
 	// Find an example of errors.As in the Login() method.
 	ErrInvalidStatusCode = &ReqError{Code: -1}
 	// ErrNilClient is returned if you attempt a request with a nil http.Client.
-	ErrNilClient = fmt.Errorf("http.Client must not be nil")
+	ErrNilClient = errors.New("http.Client must not be nil")
 	// ErrNilInterface is returned by *Into() methods when a nil interface is provided.
-	ErrNilInterface = fmt.Errorf("cannot unmarshal data into a nil or empty interface")
+	ErrNilInterface = errors.New("cannot unmarshal data into a nil or empty interface")
 	// ErrInvalidAPIKey is returned if we know the API key didn't work.
-	ErrInvalidAPIKey = fmt.Errorf("API Key may be incorrect")
+	ErrInvalidAPIKey = errors.New("API Key may be incorrect")
 	// ErrRequestError is returned when bad input is provided.
-	ErrRequestError = fmt.Errorf("request error")
+	ErrRequestError = errors.New("request error")
 )
 
 // Config is the data needed to poll Radarr or Sonarr or Lidarr or Readarr.

--- a/starrcmd/lidarr_test.go
+++ b/starrcmd/lidarr_test.go
@@ -1,4 +1,3 @@
-//nolint:paralleltest
 package starrcmd_test
 
 import (

--- a/starrcmd/prowlarr.go
+++ b/starrcmd/prowlarr.go
@@ -14,7 +14,7 @@ type ProwlarrApplicationUpdate struct {
 
 // ProwlarrHealthIssue is the HealthIssue event.
 type ProwlarrHealthIssue struct {
-	Message   string `env:"prowlarr_health_issue_message"` // some message about sme problem
+	Message   string `env:"prowlarr_health_issue_message"` // some message about some problem
 	IssueType string `env:"prowlarr_health_issue_type"`    // NeverSeenOne
 	Wiki      string `env:"prowlarr_health_issue_wiki"`    // something
 	Level     string `env:"prowlarr_health_issue_level"`   // Warning

--- a/starrcmd/prowlarr_test.go
+++ b/starrcmd/prowlarr_test.go
@@ -1,4 +1,4 @@
-//nolint:paralleltest,dupl
+//nolint:dupl
 package starrcmd_test
 
 import (

--- a/starrcmd/radarr_test.go
+++ b/starrcmd/radarr_test.go
@@ -1,4 +1,4 @@
-//nolint:paralleltest,cyclop
+//nolint:cyclop
 package starrcmd_test
 
 import (

--- a/starrcmd/readarr_test.go
+++ b/starrcmd/readarr_test.go
@@ -1,4 +1,4 @@
-//nolint:paralleltest,dupl
+//nolint:dupl
 package starrcmd_test
 
 import (

--- a/starrcmd/sonarr_test.go
+++ b/starrcmd/sonarr_test.go
@@ -1,4 +1,3 @@
-//nolint:paralleltest
 package starrcmd_test
 
 import (

--- a/starrtest/starrtest.go
+++ b/starrtest/starrtest.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // MockData allows generic testing of http inputs and outputs.
@@ -54,11 +55,11 @@ func (test *MockData) GetMockServer(t *testing.T) *httptest.Server {
 			"test.ExpectedMethod does not match the actual method")
 
 		body, err := io.ReadAll(req.Body)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.EqualValues(t, test.ExpectedRequest, string(body),
 			"test.ExpectedRequest does not match body for actual request")
 
 		_, err = writer.Write([]byte(test.ResponseBody))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}))
 }


### PR DESCRIPTION
- Adds 'force save' parameter when adding (creating): Indexers, Import Lists and Download Clients. All apps.
- Renames `CreateImportList` to `AddImportList` for Radarr (to match the other apps).
- Adds `AddExclusion` support to all apps.
- Updates linter and fixes some lint problems.
- Updates `Naming` (config/naming) in Radarr and Sonarr.
- Updates `MediaManagement` (config/mediaManagement) in Radarr and Sonarr.

_force save doesn't even seem to work on indexers or download clients_